### PR TITLE
support anyhow error

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bgpkit-broker"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2018"
 authors = ["Mingwei Zhang <mingwei@bgpkit.com>"]
 readme = "README.md"
@@ -19,3 +19,6 @@ serde={version="1", features = ["derive"]}
 log="0.4"
 chrono = { version = "0.4", features = ["serde"] }
 serde_json = "1"
+
+[dev-dependencies]
+anyhow = "1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 //! Error handling module.
+use std::error::Error;
 use std::fmt::{Display, Formatter};
 
 /// Broker error enum.
@@ -13,6 +14,8 @@ pub enum BrokerError {
     BrokerError(String),
 }
 
+impl Error for BrokerError {}
+
 impl Display for BrokerError {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -25,5 +28,19 @@ impl Display for BrokerError {
 impl From<ureq::Error> for BrokerError {
     fn from(e: ureq::Error) -> Self {
         BrokerError::NetworkError(e.to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{BgpkitBroker, CollectorLatestItem};
+
+    #[test]
+    fn test_anyhow() {
+
+        fn test_error() -> anyhow::Result<Vec<CollectorLatestItem>> {
+            Ok(BgpkitBroker::new().latest()?)
+        }
+        let _res = test_error();
     }
 }


### PR DESCRIPTION
This PR adds implementation of the standard `Error` trait, which thus allows the broker error to be passed to `anyhow::Result`.

This fixes #15.