### PR TITLE
by default load preconfigured collectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@ oneio = {version="0.11.0", features = ["lib", "s3"], optional = true}
 regex = { version = "1", optional = true }
 scraper = { version = "0.17", optional = true }
 tokio = {version="1", optional = true, features = ["full"] }
+lazy_static = {version="1", optional = true}
 
 # api dependencies
 poem = {version="1", optional = true}
@@ -64,7 +65,7 @@ cli = [
     # command-line interface
     "clap", "dirs", "envy", "humantime", "num_cpus", "tracing-subscriber", "tabled",
     # crawler
-    "futures", "oneio", "regex", "scraper", "tokio",
+    "futures", "oneio", "regex", "scraper", "tokio", "lazy_static",
     # database
     "duckdb", "r2d2",
     # RESTful API

--- a/src/cli/broker.rs
+++ b/src/cli/broker.rs
@@ -216,8 +216,7 @@ fn main() {
                 std::thread::spawn(move || {
                     let rt = get_tokio_runtime();
 
-                    // load all collectors from configuration file
-                    let collectors = load_collectors(config.collectors_config.as_str()).unwrap();
+                    let collectors = load_collectors(config.collectors_config).unwrap();
 
                     rt.block_on(async {
                         let mut interval =
@@ -326,7 +325,7 @@ fn main() {
 
             let db = LocalBrokerDb::new(config.db_file_path.as_str(), false, None).unwrap();
             // load all collectors from configuration file
-            let collectors = load_collectors(config.collectors_config.as_str()).unwrap();
+            let collectors = load_collectors(config.collectors_config).unwrap();
 
             rt.block_on(async {
                 update_database(db, collectors).await;

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -7,7 +7,7 @@ use std::fs::create_dir_all;
 /// Main environment variables, each with a default value:
 ///
 /// - `BGPKIT_BROKER_COLLECTORS_CONFIG`: path to the file contains the list of collectors
-///     - default: `https://spaces.bgpkit.org/broker/collectors.json`
+///     - default: pre-configured collectors, should be the same as `https://spaces.bgpkit.org/broker/collectors.json`
 /// - `BGPKIT_BROKER_LOCAL_DB_PATH`: path to the db file that stores the broker data locally
 ///     - default: `./bgpkit/broker.duckdb`
 /// - `BGPKIT_BROKER_DB_BOOTSTRAP_PATH`: path to the db file bootstrap parquet file
@@ -25,8 +25,7 @@ use std::fs::create_dir_all;
 #[derive(Serialize, Deserialize, Debug)]
 pub struct BrokerConfig {
     /// path to the file contains the list of collectors
-    #[serde(default = "default_collectors_file")]
-    pub collectors_config: String,
+    pub collectors_config: Option<String>,
 
     /// path to the db file that stores the broker data locally
     #[serde(default = "default_db_file_path")]
@@ -72,10 +71,6 @@ fn get_bgpkit_root_dir() -> String {
     let bgpkit_dir = format!("{}/.bgpkit", home_dir.as_str());
     create_dir_all(bgpkit_dir.as_str()).unwrap();
     bgpkit_dir
-}
-
-fn default_collectors_file() -> String {
-    "https://spaces.bgpkit.org/broker/collectors.json".to_string()
 }
 
 fn default_db_file_path() -> String {

--- a/src/crawler/collector.rs
+++ b/src/crawler/collector.rs
@@ -1,6 +1,8 @@
 use crate::BrokerError;
+use lazy_static::lazy_static;
 use oneio::OneIoError;
 use serde::{Deserialize, Serialize};
+use tracing::info;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Collector {
@@ -9,35 +11,46 @@ pub struct Collector {
     pub url: String,
 }
 
-pub fn load_collectors(path: &str) -> Result<Vec<Collector>, BrokerError> {
-    #[derive(Debug, Serialize, Deserialize)]
-    struct Config {
-        projects: Vec<ConfProject>,
-    }
-    #[derive(Debug, Serialize, Deserialize)]
-    struct ConfProject {
-        name: String,
-        collectors: Vec<ConfCollector>,
-    }
-    #[derive(Debug, Serialize, Deserialize)]
-    struct ConfCollector {
-        id: String,
-        url: String,
-    }
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct Config {
+    projects: Vec<ConfProject>,
+}
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ConfProject {
+    name: String,
+    collectors: Vec<ConfCollector>,
+}
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ConfCollector {
+    id: String,
+    url: String,
+}
 
-    let config = match oneio::read_json_struct::<Config>(path) {
-        Ok(config) => config,
-        Err(e) => match e {
-            OneIoError::IoError(e) => {
-                return Err(BrokerError::IoError(e));
+pub fn load_collectors(path: Option<impl Into<String>>) -> Result<Vec<Collector>, BrokerError> {
+    // load config
+    let config: Config = match path {
+        None => {
+            info!("loading default collectors config");
+            DEFAULT_COLLECTORS_CONFIG.clone()
+        }
+        Some(path) => {
+            let path_str: String = path.into();
+            info!("loading collectors config from {}", path_str.as_str());
+            match oneio::read_json_struct::<Config>(path_str.as_str()) {
+                Ok(config) => config,
+                Err(e) => match e {
+                    OneIoError::IoError(e) => {
+                        return Err(BrokerError::IoError(e));
+                    }
+                    OneIoError::JsonParsingError(e) => {
+                        return Err(BrokerError::ConfigJsonError(e));
+                    }
+                    _ => {
+                        return Err(BrokerError::ConfigUnknownError(e.to_string()));
+                    }
+                },
             }
-            OneIoError::JsonParsingError(e) => {
-                return Err(BrokerError::ConfigJsonError(e));
-            }
-            _ => {
-                return Err(BrokerError::ConfigUnknownError(e.to_string()));
-            }
-        },
+        }
     };
 
     Ok(config
@@ -59,13 +72,287 @@ pub fn load_collectors(path: &str) -> Result<Vec<Collector>, BrokerError> {
         .collect())
 }
 
+lazy_static! {
+    pub static ref DEFAULT_COLLECTORS_CONFIG: Config = serde_json::from_str(
+        r#"
+    {
+  "projects": [
+    {
+      "name": "riperis",
+      "collectors": [
+        {
+          "id": "rrc00",
+          "url": "https://data.ris.ripe.net/rrc00"
+        },
+        {
+          "id": "rrc01",
+          "url": "https://data.ris.ripe.net/rrc01"
+        },
+        {
+          "id": "rrc02",
+          "url": "https://data.ris.ripe.net/rrc02"
+        },
+        {
+          "id": "rrc03",
+          "url": "https://data.ris.ripe.net/rrc03"
+        },
+        {
+          "id": "rrc04",
+          "url": "https://data.ris.ripe.net/rrc04"
+        },
+        {
+          "id": "rrc05",
+          "url": "https://data.ris.ripe.net/rrc05"
+        },
+        {
+          "id": "rrc06",
+          "url": "https://data.ris.ripe.net/rrc06"
+        },
+        {
+          "id": "rrc07",
+          "url": "https://data.ris.ripe.net/rrc07"
+        },
+        {
+          "id": "rrc08",
+          "url": "https://data.ris.ripe.net/rrc08"
+        },
+        {
+          "id": "rrc09",
+          "url": "https://data.ris.ripe.net/rrc09"
+        },
+        {
+          "id": "rrc10",
+          "url": "https://data.ris.ripe.net/rrc10"
+        },
+        {
+          "id": "rrc11",
+          "url": "https://data.ris.ripe.net/rrc11"
+        },
+        {
+          "id": "rrc12",
+          "url": "https://data.ris.ripe.net/rrc12"
+        },
+        {
+          "id": "rrc13",
+          "url": "https://data.ris.ripe.net/rrc13"
+        },
+        {
+          "id": "rrc14",
+          "url": "https://data.ris.ripe.net/rrc14"
+        },
+        {
+          "id": "rrc15",
+          "url": "https://data.ris.ripe.net/rrc15"
+        },
+        {
+          "id": "rrc16",
+          "url": "https://data.ris.ripe.net/rrc16"
+        },
+        {
+          "id": "rrc18",
+          "url": "https://data.ris.ripe.net/rrc18"
+        },
+        {
+          "id": "rrc19",
+          "url": "https://data.ris.ripe.net/rrc19"
+        },
+        {
+          "id": "rrc20",
+          "url": "https://data.ris.ripe.net/rrc20"
+        },
+        {
+          "id": "rrc21",
+          "url": "https://data.ris.ripe.net/rrc21"
+        },
+        {
+          "id": "rrc22",
+          "url": "https://data.ris.ripe.net/rrc22"
+        },
+        {
+          "id": "rrc23",
+          "url": "https://data.ris.ripe.net/rrc23"
+        },
+        {
+          "id": "rrc24",
+          "url": "https://data.ris.ripe.net/rrc24"
+        },
+        {
+          "id": "rrc25",
+          "url": "https://data.ris.ripe.net/rrc25"
+        },
+        {
+          "id": "rrc26",
+          "url": "https://data.ris.ripe.net/rrc26"
+        }
+      ]
+    },
+    {
+      "name": "routeviews",
+      "collectors": [
+        {
+          "id": "route-views2",
+          "url": "http://archive.routeviews.org/bgpdata"
+        },
+        {
+          "id": "route-views3",
+          "url": "http://archive.routeviews.org/route-views3/bgpdata"
+        },
+        {
+          "id": "route-views4",
+          "url": "http://archive.routeviews.org/route-views4/bgpdata"
+        },
+        {
+          "id": "route-views5",
+          "url": "http://archive.routeviews.org/route-views5/bgpdata"
+        },
+        {
+          "id": "route-views6",
+          "url": "http://archive.routeviews.org/route-views6/bgpdata"
+        },
+        {
+          "id":"route-views.amsix",
+          "url": "http://archive.routeviews.org/route-views.amsix/bgpdata"
+        },
+        {
+          "id":"route-views.chicago",
+          "url": "http://archive.routeviews.org/route-views.chicago/bgpdata"
+        },
+        {
+          "id":"route-views.chile",
+          "url": "http://archive.routeviews.org/route-views.chile/bgpdata"
+        },
+        {
+          "id":"route-views.eqix",
+          "url": "http://archive.routeviews.org/route-views.eqix/bgpdata"
+        },
+        {
+          "id":"route-views.flix",
+          "url": "http://archive.routeviews.org/route-views.flix/bgpdata"
+        },
+        {
+          "id":"route-views.gorex",
+          "url": "http://archive.routeviews.org/route-views.gorex/bgpdata"
+        },
+        {
+          "id":"route-views.isc",
+          "url": "http://archive.routeviews.org/route-views.isc/bgpdata"
+        },
+        {
+          "id":"route-views.kixp",
+          "url": "http://archive.routeviews.org/route-views.kixp/bgpdata"
+        },
+        {
+          "id":"route-views.jinx",
+          "url": "http://archive.routeviews.org/route-views.jinx/bgpdata"
+        },
+        {
+          "id":"route-views.linx",
+          "url": "http://archive.routeviews.org/route-views.linx/bgpdata"
+        },
+        {
+          "id":"route-views.napafrica",
+          "url": "http://archive.routeviews.org/route-views.napafrica/bgpdata"
+        },
+        {
+          "id":"route-views.nwax",
+          "url": "http://archive.routeviews.org/route-views.nwax/bgpdata"
+        },
+        {
+          "id":"route-views.phoix",
+          "url": "http://archive.routeviews.org/route-views.phoix/bgpdata"
+        },
+        {
+          "id":"route-views.telxatl",
+          "url": "http://archive.routeviews.org/route-views.telxatl/bgpdata"
+        },
+        {
+          "id":"route-views.wide",
+          "url": "http://archive.routeviews.org/route-views.wide/bgpdata"
+        },
+        {
+          "id":"route-views.sydney",
+          "url": "http://archive.routeviews.org/route-views.sydney/bgpdata"
+        },
+        {
+          "id":"route-views.saopaulo",
+          "url": "http://archive.routeviews.org/route-views.saopaulo/bgpdata"
+        },
+        {
+          "id":"route-views2.saopaulo",
+          "url": "http://archive.routeviews.org/route-views2.saopaulo/bgpdata"
+        },
+        {
+          "id":"route-views.sg",
+          "url": "http://archive.routeviews.org/route-views.sg/bgpdata"
+        },
+        {
+          "id":"route-views.perth",
+          "url": "http://archive.routeviews.org/route-views.perth/bgpdata"
+        },
+        {
+          "id":"route-views.peru",
+          "url": "http://archive.routeviews.org/route-views.peru/bgpdata"
+        },
+        {
+          "id":"route-views.sfmix",
+          "url": "http://archive.routeviews.org/route-views.sfmix/bgpdata"
+        },
+        {
+          "id":"route-views.siex",
+          "url": "http://archive.routeviews.org/route-views.siex/bgpdata"
+        },
+        {
+          "id":"route-views.soxrs",
+          "url": "http://archive.routeviews.org/route-views.soxrs/bgpdata"
+        },
+        {
+          "id":"route-views.mwix",
+          "url": "http://archive.routeviews.org/route-views.mwix/bgpdata"
+        },
+        {
+          "id":"route-views.rio",
+          "url": "http://archive.routeviews.org/route-views.rio/bgpdata"
+        },
+        {
+          "id":"route-views.fortaleza",
+          "url": "http://archive.routeviews.org/route-views.fortaleza/bgpdata"
+        },
+        {
+          "id":"route-views.gixa",
+          "url": "http://archive.routeviews.org/route-views.gixa/bgpdata"
+        },
+        {
+          "id":"route-views.bdix",
+          "url": "http://archive.routeviews.org/route-views.bdix/bgpdata"
+        },
+        {
+          "id":"route-views.bknix",
+          "url": "http://archive.routeviews.org/route-views.bknix/bgpdata"
+        },
+        {
+          "id":"route-views.ny",
+          "url": "http://archive.routeviews.org/route-views.ny/bgpdata"
+        },
+        {
+          "id":"route-views.uaeix",
+          "url": "http://archive.routeviews.org/route-views.uaeix/bgpdata"
+        }
+      ]
+    }
+  ]
+}
+    "#
+    )
+    .unwrap();
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
 
     #[test]
     fn test_load_collectors() {
-        let collectors = load_collectors("deployment/collectors.json").unwrap();
+        let collectors = load_collectors(Some("deployment/collectors.json")).unwrap();
         dbg!(collectors);
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -481,7 +481,7 @@ mod tests {
     #[test]
     fn test_search() {
         tracing_subscriber::fmt::init();
-        let db = LocalBrokerDb::new("broker-test.duckdb", false).unwrap();
+        let db = LocalBrokerDb::new("broker-test.duckdb", false, None).unwrap();
 
         let items = db
             .search_items(


### PR DESCRIPTION
this avoids one level of dependency on bgpkit remote hosting