### PR TITLE
configure default bootstrap length

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,4 +19,4 @@ FROM debian:bullseye
 COPY --from=build /my_project/target/release/bgpkit-broker /usr/local/bin/bgpkit-broker
 RUN DEBIAN=NONINTERACTIVE apt update; apt install -y curl libssl-dev ca-certificates tzdata cron; rm -rf /var/lib/apt/lists/*
 
-ENTRYPOINT bash -c '/usr/local/bin/bgpkit-broker serve'
+ENTRYPOINT bash -c '/usr/local/bin/bgpkit-broker serve --full-bootstrap'

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -27,6 +27,10 @@ pub struct BrokerConfig {
     /// path to the file contains the list of collectors
     pub collectors_config: Option<String>,
 
+    /// when need facing empty database, how many days to bootstrap
+    #[serde(default = "default_db_bootstrap_days")]
+    pub db_bootstrap_days: u32,
+
     /// path to the db file that stores the broker data locally
     #[serde(default = "default_db_file_path")]
     pub db_file_path: String,
@@ -79,6 +83,10 @@ fn default_db_file_path() -> String {
 
 fn default_db_backup_duckdb_path() -> String {
     format!("{}/broker-backup.duckdb", get_bgpkit_root_dir())
+}
+
+fn default_db_bootstrap_days() -> u32 {
+    30
 }
 
 fn default_db_backup_parquet_path() -> String {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -31,7 +31,7 @@ impl LocalBrokerDb {
     pub fn new(
         path: &str,
         force_reset: bool,
-        try_bootstrap: Option<String>,
+        bootstrap_path: Option<String>,
     ) -> Result<Self, BrokerError> {
         info!("open local broker db at {}", path);
         let writer_config = Config::default().access_mode(AccessMode::ReadWrite)?;
@@ -41,10 +41,10 @@ impl LocalBrokerDb {
         let mut db = LocalBrokerDb { conn_pool };
         db.create_table(force_reset).unwrap();
 
-        if let Some(remote_path) = try_bootstrap {
+        if let Some(remote_path) = bootstrap_path {
             if db.get_entry_count()? <= 100_000 {
                 info!(
-                    "database needs bootstrap, bootstrapping from {}...",
+                    "database doing full bootstrap from {}...",
                     remote_path.as_str()
                 );
                 match remote_path.ends_with("duckdb") {
@@ -65,7 +65,7 @@ impl LocalBrokerDb {
         if let Err(error) = oneio::download(remote_path, local_path, None) {
             return Err(BrokerError::BrokerError(error.to_string()));
         };
-        Ok(LocalBrokerDb::new(local_path, false, None)?)
+        LocalBrokerDb::new(local_path, false, None)
     }
 
     /// Bootstrap from remote parquet file


### PR DESCRIPTION
Full-bootstrap now requires a flag `--full-bootstrap` to enable. By default, we crawl 30-day worth of data. The period length is configurable by `BGPKIT_BROKER_DB_BOOTSTRAP_DAYS=30` environment variable.