### PR TITLE
find sqlite command path with `which` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,9 @@ tracing-subscriber = {version="0.3", optional=true}
 indicatif = { version = "0.17.7", optional = true }
 futures-util = { version = "0.3.28", optional = true }
 itertools = { version = "0.12.0" , optional = true }
-tempfile = "3.8"
 dotenvy = { version = "0.15" , optional = true }
+tempfile = { version = "3.8", optional = true }
+which = { version = "5.0", optional = true }
 
 # crawler dependencies
 futures = {version="0.3", optional = true}
@@ -66,7 +67,7 @@ sqlx = { version = "0.7", features = [ "runtime-tokio", "sqlite"], optional = tr
 default=[]
 cli = [
     # command-line interface
-    "clap", "dirs", "humantime", "num_cpus", "tracing-subscriber", "tabled", "itertools", "dotenvy",
+    "clap", "dirs", "humantime", "num_cpus", "tracing-subscriber", "tabled", "itertools", "dotenvy", "tempfile", "which",
     # crawler
     "futures", "oneio", "regex", "scraper", "tokio", "lazy_static",
     # database

--- a/src/cli/backup.rs
+++ b/src/cli/backup.rs
@@ -9,7 +9,15 @@ pub(crate) fn backup_database(from: &str, to: &str, force: bool) -> Result<(), S
         exit(1);
     }
 
-    let mut command = Command::new("sqlite3");
+    let sqlite_path = match which::which("sqlite3") {
+        Ok(p) => p.to_string_lossy().to_string(),
+        Err(_) => {
+            error!("sqlite3 not found in PATH, please install sqlite3 first.");
+            exit(1);
+        }
+    };
+
+    let mut command = Command::new(sqlite_path.as_str());
     command.arg(from).arg(format!(".backup {}", to).as_str());
 
     let command_str = format!(


### PR DESCRIPTION
This PR adds `which` crate to find `sqlite3` command path instead of assuming `sqlite3` is always in `PATH`.