### PR TITLE
allow force specify sqlite cmd path

### DIFF
--- a/src/cli/backup.rs
+++ b/src/cli/backup.rs
@@ -2,19 +2,27 @@ use itertools::Itertools;
 use std::process::{exit, Command};
 use tracing::{error, info};
 
-pub(crate) fn backup_database(from: &str, to: &str, force: bool) -> Result<(), String> {
+pub(crate) fn backup_database(
+    from: &str,
+    to: &str,
+    force: bool,
+    sqlite_cmd_path: Option<String>,
+) -> Result<(), String> {
     // back up to local directory
     if std::fs::metadata(to).is_ok() && !force {
         error!("The specified database path already exists, skip backing up.");
         exit(1);
     }
 
-    let sqlite_path = match which::which("sqlite3") {
-        Ok(p) => p.to_string_lossy().to_string(),
-        Err(_) => {
-            error!("sqlite3 not found in PATH, please install sqlite3 first.");
-            exit(1);
-        }
+    let sqlite_path = match sqlite_cmd_path {
+        Some(p) => p,
+        None => match which::which("sqlite3") {
+            Ok(p) => p.to_string_lossy().to_string(),
+            Err(_) => {
+                error!("sqlite3 not found in PATH, please install sqlite3 first.");
+                exit(1);
+            }
+        },
     };
 
     let mut command = Command::new(sqlite_path.as_str());

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -141,6 +141,10 @@ enum Commands {
         /// force writing backup file to existing file if specified
         #[clap(short, long)]
         force: bool,
+
+        /// specify sqlite3 command path
+        #[clap(short, long)]
+        sqlite_cmd_path: Option<String>,
     },
 
     /// Search MRT files in Broker db
@@ -368,7 +372,12 @@ fn main() {
                 download_file(&from, &db_path, silent).await.unwrap();
             });
         }
-        Commands::Backup { from, to, force } => {
+        Commands::Backup {
+            from,
+            to,
+            force,
+            sqlite_cmd_path,
+        } => {
             if do_log {
                 enable_logging();
             }
@@ -381,7 +390,7 @@ fn main() {
 
             if is_local_path(&to) {
                 // back up to local directory
-                backup_database(&from, &to, force).unwrap();
+                backup_database(&from, &to, force, sqlite_cmd_path).unwrap();
                 return;
             }
 
@@ -395,7 +404,7 @@ fn main() {
                     .unwrap()
                     .to_string();
 
-                match backup_database(&from, &temp_file_path, force) {
+                match backup_database(&from, &temp_file_path, force, sqlite_cmd_path) {
                     Ok(_) => {
                         info!(
                             "uploading backup file {} to S3 at s3://{}/{}",


### PR DESCRIPTION
This works for systems where the `sqlite3` command is not located in the common directories