### PR TITLE
add new route-views collectors

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ serde_json = "1"
 thiserror = "1.0"
 tracing = "0.1"
 lazy_static = "1"
+dotenvy = "0.15"
 
 #############################################
 # Optional dependencies
@@ -45,14 +46,13 @@ tracing-subscriber = { version = "0.3", optional = true }
 indicatif = { version = "0.17.7", optional = true }
 futures-util = { version = "0.3.28", optional = true }
 itertools = { version = "0.12.0", optional = true }
-dotenvy = { version = "0.15", optional = true }
 tempfile = { version = "3.8", optional = true }
 which = { version = "5.0", optional = true }
 bgpkit-commons = { version = "0.5", optional = true }
 
 # crawler dependencies
 futures = { version = "0.3", optional = true }
-oneio = { version = "0.16.0", features = ["s3"], optional = true }
+oneio = { version = "0.17.0", features = ["s3"], optional = true }
 regex = { version = "1", optional = true }
 scraper = { version = "0.17", optional = true }
 tokio = { version = "1", optional = true, features = ["full"] }
@@ -73,7 +73,7 @@ async-nats = { version = "0.34.0", optional = true }
 default = []
 cli = [
     # command-line interface
-    "clap", "dirs", "humantime", "num_cpus", "tracing-subscriber", "tabled", "itertools", "dotenvy", "tempfile", "which",
+    "clap", "dirs", "humantime", "num_cpus", "tracing-subscriber", "tabled", "itertools", "tempfile", "which",
     "bgpkit-commons",
     # crawler
     "futures", "oneio", "regex", "scraper", "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "1.0"
 tracing = "0.1"
+lazy_static = "1"
 
 #############################################
 # Optional dependencies
@@ -55,7 +56,6 @@ oneio = { version = "0.16.0", features = ["s3"], optional = true }
 regex = { version = "1", optional = true }
 scraper = { version = "0.17", optional = true }
 tokio = { version = "1", optional = true, features = ["full"] }
-lazy_static = { version = "1", optional = true }
 
 # api dependencies
 axum = { version = "0.7", optional = true }
@@ -76,7 +76,7 @@ cli = [
     "clap", "dirs", "humantime", "num_cpus", "tracing-subscriber", "tabled", "itertools", "dotenvy", "tempfile", "which",
     "bgpkit-commons",
     # crawler
-    "futures", "oneio", "regex", "scraper", "tokio", "lazy_static",
+    "futures", "oneio", "regex", "scraper", "tokio",
     # notification
     "nats",
     # database

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -268,7 +268,7 @@ async fn update_database(
 
     let mut collector_updated = false;
     for c in &collectors {
-        if let None = latest_ts_map.get(&c.id) {
+        if !latest_ts_map.contains_key(&c.id) {
             info!(
                 "collector {} not found in database, inserting collector meta information first...",
                 &c.id

--- a/src/collector.rs
+++ b/src/collector.rs
@@ -1,6 +1,7 @@
 use crate::BrokerError;
 use lazy_static::lazy_static;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use tracing::info;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -12,7 +13,7 @@ pub struct Collector {
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct Config {
-    projects: Vec<ConfProject>,
+    pub projects: Vec<ConfProject>,
 }
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct ConfProject {
@@ -23,6 +24,19 @@ pub struct ConfProject {
 pub struct ConfCollector {
     id: String,
     url: String,
+}
+
+impl Config {
+    pub fn to_project_map(&self) -> HashMap<String, String> {
+        let mut map = HashMap::new();
+        for p in &self.projects {
+            let project = p.name.clone();
+            for c in &p.collectors {
+                map.insert(c.id.clone(), project.clone());
+            }
+        }
+        map
+    }
 }
 
 pub fn load_collectors() -> Result<Vec<Collector>, BrokerError> {

--- a/src/crawler/collector.rs
+++ b/src/crawler/collector.rs
@@ -167,152 +167,184 @@ lazy_static! {
       "name": "routeviews",
       "collectors": [
         {
+          "id": "amsix.ams",
+          "url": "https://archive.routeviews.org/amsix.ams/bgpdata"
+        },
+        {
+          "id": "cix.atl",
+          "url": "https://archive.routeviews.org/cix.atl/bgpdata"
+        },
+        {
+          "id": "decix.jhb",
+          "url": "https://archive.routeviews.org/decix.jhb/bgpdata"
+        },
+        {
+          "id": "iraq-ixp.bgw",
+          "url": "https://archive.routeviews.org/iraq-ixp.bgw/bgpdata"
+        },
+        {
+          "id": "pacwave.lax",
+          "url": "https://archive.routeviews.org/pacwave.lax/bgpdata"
+        },
+        {
+          "id": "pit.scl",
+          "url": "https://archive.routeviews.org/pit.scl/bgpdata"
+        },
+        {
+          "id": "pitmx.qro",
+          "url": "https://archive.routeviews.org/pitmx.qro/bgpdata"
+        },
+        {
           "id": "route-views2",
-          "url": "http://archive.routeviews.org/bgpdata"
+          "url": "https://archive.routeviews.org/bgpdata"
         },
         {
           "id": "route-views3",
-          "url": "http://archive.routeviews.org/route-views3/bgpdata"
+          "url": "https://archive.routeviews.org/route-views3/bgpdata"
         },
         {
           "id": "route-views4",
-          "url": "http://archive.routeviews.org/route-views4/bgpdata"
+          "url": "https://archive.routeviews.org/route-views4/bgpdata"
         },
         {
           "id": "route-views5",
-          "url": "http://archive.routeviews.org/route-views5/bgpdata"
+          "url": "https://archive.routeviews.org/route-views5/bgpdata"
         },
         {
           "id": "route-views6",
-          "url": "http://archive.routeviews.org/route-views6/bgpdata"
+          "url": "https://archive.routeviews.org/route-views6/bgpdata"
+        },
+        {
+          "id": "route-views7",
+          "url": "https://archive.routeviews.org/route-views7/bgpdata"
         },
         {
           "id":"route-views.amsix",
-          "url": "http://archive.routeviews.org/route-views.amsix/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.amsix/bgpdata"
         },
         {
           "id":"route-views.chicago",
-          "url": "http://archive.routeviews.org/route-views.chicago/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.chicago/bgpdata"
         },
         {
           "id":"route-views.chile",
-          "url": "http://archive.routeviews.org/route-views.chile/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.chile/bgpdata"
         },
         {
           "id":"route-views.eqix",
-          "url": "http://archive.routeviews.org/route-views.eqix/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.eqix/bgpdata"
         },
         {
           "id":"route-views.flix",
-          "url": "http://archive.routeviews.org/route-views.flix/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.flix/bgpdata"
         },
         {
           "id":"route-views.gorex",
-          "url": "http://archive.routeviews.org/route-views.gorex/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.gorex/bgpdata"
         },
         {
           "id":"route-views.isc",
-          "url": "http://archive.routeviews.org/route-views.isc/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.isc/bgpdata"
         },
         {
           "id":"route-views.kixp",
-          "url": "http://archive.routeviews.org/route-views.kixp/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.kixp/bgpdata"
         },
         {
           "id":"route-views.jinx",
-          "url": "http://archive.routeviews.org/route-views.jinx/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.jinx/bgpdata"
         },
         {
           "id":"route-views.linx",
-          "url": "http://archive.routeviews.org/route-views.linx/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.linx/bgpdata"
         },
         {
           "id":"route-views.napafrica",
-          "url": "http://archive.routeviews.org/route-views.napafrica/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.napafrica/bgpdata"
         },
         {
           "id":"route-views.nwax",
-          "url": "http://archive.routeviews.org/route-views.nwax/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.nwax/bgpdata"
         },
         {
           "id":"route-views.phoix",
-          "url": "http://archive.routeviews.org/route-views.phoix/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.phoix/bgpdata"
         },
         {
           "id":"route-views.telxatl",
-          "url": "http://archive.routeviews.org/route-views.telxatl/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.telxatl/bgpdata"
         },
         {
           "id":"route-views.wide",
-          "url": "http://archive.routeviews.org/route-views.wide/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.wide/bgpdata"
         },
         {
           "id":"route-views.sydney",
-          "url": "http://archive.routeviews.org/route-views.sydney/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.sydney/bgpdata"
         },
         {
           "id":"route-views.saopaulo",
-          "url": "http://archive.routeviews.org/route-views.saopaulo/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.saopaulo/bgpdata"
         },
         {
           "id":"route-views2.saopaulo",
-          "url": "http://archive.routeviews.org/route-views2.saopaulo/bgpdata"
+          "url": "https://archive.routeviews.org/route-views2.saopaulo/bgpdata"
         },
         {
           "id":"route-views.sg",
-          "url": "http://archive.routeviews.org/route-views.sg/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.sg/bgpdata"
         },
         {
           "id":"route-views.perth",
-          "url": "http://archive.routeviews.org/route-views.perth/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.perth/bgpdata"
         },
         {
           "id":"route-views.peru",
-          "url": "http://archive.routeviews.org/route-views.peru/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.peru/bgpdata"
         },
         {
           "id":"route-views.sfmix",
-          "url": "http://archive.routeviews.org/route-views.sfmix/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.sfmix/bgpdata"
         },
         {
           "id":"route-views.siex",
-          "url": "http://archive.routeviews.org/route-views.siex/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.siex/bgpdata"
         },
         {
           "id":"route-views.soxrs",
-          "url": "http://archive.routeviews.org/route-views.soxrs/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.soxrs/bgpdata"
         },
         {
           "id":"route-views.mwix",
-          "url": "http://archive.routeviews.org/route-views.mwix/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.mwix/bgpdata"
         },
         {
           "id":"route-views.rio",
-          "url": "http://archive.routeviews.org/route-views.rio/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.rio/bgpdata"
         },
         {
           "id":"route-views.fortaleza",
-          "url": "http://archive.routeviews.org/route-views.fortaleza/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.fortaleza/bgpdata"
         },
         {
           "id":"route-views.gixa",
-          "url": "http://archive.routeviews.org/route-views.gixa/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.gixa/bgpdata"
         },
         {
           "id":"route-views.bdix",
-          "url": "http://archive.routeviews.org/route-views.bdix/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.bdix/bgpdata"
         },
         {
           "id":"route-views.bknix",
-          "url": "http://archive.routeviews.org/route-views.bknix/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.bknix/bgpdata"
         },
         {
           "id":"route-views.ny",
-          "url": "http://archive.routeviews.org/route-views.ny/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.ny/bgpdata"
         },
         {
           "id":"route-views.uaeix",
-          "url": "http://archive.routeviews.org/route-views.uaeix/bgpdata"
+          "url": "https://archive.routeviews.org/route-views.uaeix/bgpdata"
         }
       ]
     }

--- a/src/crawler/mod.rs
+++ b/src/crawler/mod.rs
@@ -1,4 +1,3 @@
-mod collector;
 mod common;
 mod riperis;
 mod routeviews;
@@ -12,7 +11,7 @@ use crate::{BrokerError, BrokerItem};
 use riperis::crawl_ripe_ris;
 use routeviews::crawl_routeviews;
 
-pub use collector::{load_collectors, Collector};
+use crate::Collector;
 
 pub async fn crawl_collector(
     collector: &Collector,

--- a/src/crawler/mod.rs
+++ b/src/crawler/mod.rs
@@ -4,6 +4,7 @@ mod riperis;
 mod routeviews;
 
 use chrono::NaiveDate;
+use log::info;
 use tracing::debug;
 
 // public interface
@@ -18,6 +19,10 @@ pub async fn crawl_collector(
     from_ts: Option<NaiveDate>,
 ) -> Result<Vec<BrokerItem>, BrokerError> {
     debug!("crawl collector {} from {:?}", &collector.id, from_ts);
+    if from_ts.is_none() {
+        info!("bootstrap crawl for collector {}", &collector.id);
+    }
+
     let items = match collector.project.as_str() {
         "riperis" => crawl_ripe_ris(collector, from_ts).await,
         "routeviews" => crawl_routeviews(collector, from_ts).await,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,6 +490,8 @@ impl BgpkitBroker {
                         }
                     }
                     "routeviews" | "route_views" | "rv" => {
+                        // TODO: some of the route-views collectors do not start with "route-views"
+                        // Examples: decix.jhb, pacwave.lax
                         if !item.collector_id.starts_with("route-views") {
                             matches = false
                         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,7 @@
 /*!
 # Overview
 
-[bgpkit-broker][crate] is a package that allow access the BGPKIT Broker API and search for BGP archive
+[bgpkit-broker][crate] is a package that allows accessing the BGPKIT Broker API and search for BGP archive
 files with different search parameters available.
 
 # Examples
@@ -38,7 +38,7 @@ assert_eq!(items.len(), 106);
 User can make individual queries to the BGPKIT broker backend by calling [BgpkitBroker::query_single_page]
 function.
 
-Below is an example of creating an new struct instance and make queries to the API:
+Below is an example of creating a new struct instance and make queries to the API:
 ```rust
 use bgpkit_broker::BgpkitBroker;
 
@@ -60,14 +60,14 @@ for data in res.unwrap() {
 }
 ```
 
-Making individual queries is useful when you care about specific pages, or want to implement
-customized iteration procedure. Use [BgpkitBroker::turn_page] to manually change to a different
+Making individual queries is useful when you care about a specific page or want to implement
+ a customized iteration procedure. Use [BgpkitBroker::turn_page] to manually change to a different
 page.
 
 ## Getting the Latest File for Each Collector
 
 We also provide way to fetch the latest file information for each collector available with the
-[BgpkitBroker::latest] call. The function returns JSON-deserialized result (see [CollectorLatestItem])
+[BgpkitBroker::latest] call. The function returns a JSON-deserialized result (see [CollectorLatestItem])
 to the RESTful API at <https://api.broker.bgpkit.com/v3/latest>.
 
 ```rust
@@ -152,9 +152,12 @@ impl Default for BgpkitBroker {
 }
 
 impl BgpkitBroker {
-    /// Construct new BgpkitBroker object.
+    /// Construct a new BgpkitBroker object.
     ///
     /// The URL and query parameters can be adjusted with other functions.
+    ///
+    /// Users can opt in to accept invalid SSL certificates by setting the environment variable
+    /// `ONEIO_ACCEPT_INVALID_CERTS` to `true`.
     ///
     /// # Examples
     /// ```
@@ -168,7 +171,7 @@ impl BgpkitBroker {
     /// Configure broker URL.
     ///
     /// You can change the default broker URL to point to your own broker instance.
-    /// You can also change the URL by setting environment variable `BGPKIT_BROKER_URL`.
+    /// You can also change the URL by setting the environment variable `BGPKIT_BROKER_URL`.
     ///
     /// # Examples
     /// ```
@@ -185,8 +188,8 @@ impl BgpkitBroker {
         }
     }
 
-    /// Disable SSL certificate check.
-    pub fn disable_ssl_check(self) -> Self {
+    /// DANGER: Accept invalid SSL certificates.
+    pub fn accept_invalid_certs(self) -> Self {
         Self {
             broker_url: self.broker_url,
             query_params: self.query_params,
@@ -196,6 +199,12 @@ impl BgpkitBroker {
                 .unwrap(),
             collector_project_map: self.collector_project_map,
         }
+    }
+
+    /// Disable SSL certificate check.
+    #[deprecated(since = "0.7.1", note = "Please use `accept_invalid_certs` instead.")]
+    pub fn disable_ssl_check(self) -> Self {
+        Self::accept_invalid_certs(self)
     }
 
     /// Add a filter of starting timestamp.
@@ -224,7 +233,7 @@ impl BgpkitBroker {
         }
     }
 
-    /// Add filter of ending timestamp.
+    /// Add a filter of ending timestamp.
     ///
     /// # Examples
     ///
@@ -250,7 +259,7 @@ impl BgpkitBroker {
         }
     }
 
-    /// Add filter of collector ID (e.g. `rrc00` or `route-views2`).
+    /// Add a filter of collector ID (e.g. `rrc00` or `route-views2`).
     ///
     /// See the full list of collectors [here](https://github.com/bgpkit/bgpkit-broker-backend/blob/main/deployment/full-config.json).
     ///
@@ -278,7 +287,7 @@ impl BgpkitBroker {
         }
     }
 
-    /// Add filter of project name, i.e. `riperis` or `routeviews`.
+    /// Add a filter of project name, i.e. `riperis` or `routeviews`.
     ///
     /// # Examples
     ///
@@ -326,7 +335,7 @@ impl BgpkitBroker {
         }
     }
 
-    /// Change current page number, starting from 1.
+    /// Change the current page number, starting from 1.
     ///
     /// # Examples
     ///
@@ -430,9 +439,9 @@ impl BgpkitBroker {
         }
     }
 
-    /// Send query to get **all** data times returned.
+    /// Send a query to get **all** data times returned.
     ///
-    /// This is usually what one needs.
+    /// This usually is what one needs.
     ///
     /// # Examples
     ///
@@ -479,7 +488,7 @@ impl BgpkitBroker {
         Ok(items)
     }
 
-    /// Send query to get the **latest** data for each collector.
+    /// Send a query to get the **latest** data for each collector.
     ///
     /// The returning result is structured as a vector of [CollectorLatestItem] objects.
     ///
@@ -594,7 +603,7 @@ impl BgpkitBroker {
 /// Iterator for BGPKIT Broker that iterates through one [BrokerItem] at a time.
 ///
 /// The [IntoIterator] trait is implemented for both the struct and the reference, so that you can
-/// either iterating through items by taking the ownership of the broker, or use the reference to broker
+/// either iterate through items by taking the ownership of the broker, or use the reference to broker
 /// to iterate.
 ///
 /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -736,26 +736,31 @@ mod tests {
 
         let broker = BgpkitBroker::new().project("routeviews".to_string());
         let items = broker.latest().unwrap();
+        assert!(!items.is_empty());
         assert!(items
             .iter()
             .all(|item| !item.collector_id.starts_with("rrc")));
 
         let broker = BgpkitBroker::new().project("riperis".to_string());
         let items = broker.latest().unwrap();
+        assert!(!items.is_empty());
         assert!(items
             .iter()
             .all(|item| item.collector_id.starts_with("rrc")));
 
         let broker = BgpkitBroker::new().data_type("rib".to_string());
         let items = broker.latest().unwrap();
+        assert!(!items.is_empty());
         assert!(items.iter().all(|item| item.is_rib()));
 
         let broker = BgpkitBroker::new().data_type("update".to_string());
         let items = broker.latest().unwrap();
+        assert!(!items.is_empty());
         assert!(items.iter().all(|item| !item.is_rib()));
 
         let broker = BgpkitBroker::new().collector_id("rrc00".to_string());
         let items = broker.latest().unwrap();
+        assert!(!items.is_empty());
         assert!(items
             .iter()
             .all(|item| item.collector_id.as_str() == "rrc00"));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -490,9 +490,10 @@ impl BgpkitBroker {
                         }
                     }
                     "routeviews" | "route_views" | "rv" => {
-                        // TODO: some of the route-views collectors do not start with "route-views"
+                        // Some of the route-views collectors do not start with "route-views".
                         // Examples: decix.jhb, pacwave.lax
-                        if !item.collector_id.starts_with("route-views") {
+                        // We use the RIPE RIS rrc prefix as the filter criteria
+                        if item.collector_id.starts_with("rrc") {
                             matches = false
                         }
                     }
@@ -737,7 +738,7 @@ mod tests {
         let items = broker.latest().unwrap();
         assert!(items
             .iter()
-            .all(|item| item.collector_id.starts_with("route-views")));
+            .all(|item| !item.collector_id.starts_with("rrc")));
 
         let broker = BgpkitBroker::new().project("riperis".to_string());
         let items = broker.latest().unwrap();

--- a/src/query.rs
+++ b/src/query.rs
@@ -175,7 +175,8 @@ impl QueryParams {
     /// set the type of data to search for:
     /// - `rib`: table dump files
     /// - `updates`: BGP updates files
-    /// without specifying data type, it defaults to search for all types
+    ///
+    /// Without specifying a data type, it defaults to search for all types.
     ///
     /// ```
     /// use bgpkit_broker::QueryParams;


### PR DESCRIPTION
This PR added the code to allow fetching meta data from the new routeviews collectors.

The updated code allows bootstrapping new collectors' data by simply running the `bgpkit-broker update DB_PATH`, the same command that updates the database previously.