### PR TITLE
Add peers listing endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,42 @@
 
 All notable changes to this project will be documented in this file.
 
+## v0.7.6 - 2024-10-31
+
+### Highlights
+
+* migrate default broker API endpoint to `https://api.bgpkit.com/v3/broker`
+    * Full API docs is available at `https://api.bgpkit.com/docs`
+* add `get_peers` to `BgpkitBroker` struct
+    * fetches the list of peers for a given collector
+    * can specify filters the same way as querying MRT files
+    * available filter functions include:
+        * `.peers_asn(ASN)`
+        * `.peers_ip(IP)`
+        * `.collector_id(COLLECTOR_ID)`
+        * `.peers_only_full_feed(TRUE/FALSE)`
+    * returns `Vec<BrokerPeer>`
+
+```rust
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BrokerPeer {
+    /// The date of the latest available data.
+    pub date: NaiveDate,
+    /// The IP address of the collector peer.
+    pub ip: IpAddr,
+    /// The ASN (Autonomous System Number) of the collector peer.
+    pub asn: u32,
+    /// The name of the collector.
+    pub collector: String,
+    /// The number of IPv4 prefixes.
+    pub num_v4_pfxs: u32,
+    /// The number of IPv6 prefixes.
+    pub num_v6_pfxs: u32,
+    /// The number of connected ASNs.
+    pub num_connected_asns: u32,
+}
+```
+
 ## v0.7.5 - 2024-08-23
 
 ### [NEW] deploy at fly.io

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,9 @@ FROM debian:bookworm-slim
 # copy the build artifact from the build stage
 COPY --from=build /my_project/target/release/bgpkit-broker /usr/local/bin/bgpkit-broker
 
+RUN apt update && apt install -y curl tini
 WORKDIR /bgpkit-broker
 
 EXPOSE 40064
-ENTRYPOINT bash -c '/usr/local/bin/bgpkit-broker serve bgpkit-broker.sqlite3 --bootstrap --silent'
+ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/bgpkit-broker"]
+CMD ["serve", "bgpkit-broker.sqlite3", "--bootstrap", "--silent"]

--- a/examples/peers.rs
+++ b/examples/peers.rs
@@ -1,0 +1,36 @@
+//! This example retrieves a list of full-feed MRT collector peers from route-views.amsix and print
+//! out the top 10 peers with the most connected ASNs.
+//!
+//! Example output
+//! ```text
+//! 2024-10-31,route-views.amsix,58511,80.249.212.104,2567,960791,0
+//! 2024-10-31,route-views.amsix,267613,80.249.213.223,2268,965321,0
+//! 2024-10-31,route-views.amsix,267613,2001:7f8:1:0:a500:26:7613:1,2011,0,206667
+//! 2024-10-31,route-views.amsix,12779,80.249.209.17,1932,951788,0
+//! 2024-10-31,route-views.amsix,9002,2001:7f8:1::a500:9002:1,1896,0,202069
+//! 2024-10-31,route-views.amsix,38880,80.249.212.75,1883,992214,0
+//! 2024-10-31,route-views.amsix,58511,2001:7f8:1::a505:8511:1,1853,0,216981
+//! 2024-10-31,route-views.amsix,9002,80.249.209.216,1318,956345,0
+//! 2024-10-31,route-views.amsix,42541,80.249.212.84,1302,952091,0
+//! 2024-10-31,route-views.amsix,12779,2001:7f8:1::a501:2779:1,1247,0,201726
+//! ```
+
+fn main() {
+    let broker = bgpkit_broker::BgpkitBroker::new()
+        .collector_id("route-views.amsix")
+        .peers_only_full_feed(true);
+    let mut peers = broker.get_peers().unwrap();
+    peers.sort_by(|a, b| b.num_connected_asns.cmp(&a.num_connected_asns));
+    for peer in peers.iter().take(10) {
+        println!(
+            "{},{},{},{},{},{},{}",
+            peer.date,
+            peer.collector,
+            peer.asn,
+            peer.ip,
+            peer.num_connected_asns,
+            peer.num_v4_pfxs,
+            peer.num_v6_pfxs,
+        );
+    }
+}

--- a/examples/query.rs
+++ b/examples/query.rs
@@ -2,6 +2,7 @@ use bgpkit_broker::{BgpkitBroker, BrokerItem};
 
 pub fn main() {
     let broker = BgpkitBroker::new()
+        .broker_url("http://dev.api.bgpkit.com/v3/broker")
         .ts_start("1634693400")
         .ts_end("1634693400")
         .collector_id("rrc00,route-views2");

--- a/fly.toml
+++ b/fly.toml
@@ -8,13 +8,13 @@ primary_region = 'lax'
 
 [http_service]
 internal_port = 40064
-force_https = true
+force_https = false
 auto_stop_machines = 'off'
 processes = ['app']
 
 [[http_service.checks]]
-grace_period = "120s"
-interval = "60s"
+grace_period = "60s"
+interval = "30s"
 method = "GET"
 timeout = "5s"
 path = "/health?max_delay_secs=3600"
@@ -22,11 +22,9 @@ path = "/health?max_delay_secs=3600"
 
 [[vm]]
 memory = '1gb'
-cpu_kind = 'shared'
-cpus = 1
+size = 'shared-cpu-4x'
 
 
 [deploy]
-strategy = "rolling"
-max_unavailable = 1
+strategy = "bluegreen"
 wait_timeout = "20m"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -648,7 +648,7 @@ impl BgpkitBroker {
     /// let broker = bgpkit_broker::BgpkitBroker::new();
     /// let peers = broker.get_peers().unwrap();
     /// for peer in &peers {
-    ///     println!("{}", peer);
+    ///     println!("{:?}", peer);
     /// }
     /// ```
     ///
@@ -659,7 +659,7 @@ impl BgpkitBroker {
     ///    .collector_id("route-views2");
     /// let peers = broker.get_peers().unwrap();
     /// for peer in &peers {
-    ///    println!("{}", peer);
+    ///    println!("{:?}", peer);
     /// }
     /// ```
     ///
@@ -670,7 +670,7 @@ impl BgpkitBroker {
     ///   .peers_asn(64496);
     /// let peers = broker.get_peers().unwrap();
     /// for peer in &peers {
-    ///    println!("{}", peer);
+    ///    println!("{:?}", peer);
     /// }
     /// ```
     ///
@@ -681,7 +681,7 @@ impl BgpkitBroker {
     ///   .peers_ip("192.168.1.1".parse().unwrap());
     /// let peers = broker.get_peers().unwrap();
     /// for peer in &peers {
-    ///   println!("{}", peer);
+    ///   println!("{:?}", peer);
     /// }
     /// ```
     ///
@@ -692,7 +692,7 @@ impl BgpkitBroker {
     ///  .peers_only_full_feed(true);
     /// let peers = broker.get_peers().unwrap();
     /// for peer in &peers {
-    ///     println!("{}", peer);
+    ///     println!("{:?}", peer);
     /// }
     /// ```
     ///
@@ -704,7 +704,7 @@ impl BgpkitBroker {
     /// .peers_only_full_feed(true);
     /// let peers = broker.get_peers().unwrap();
     /// for peer in &peers {
-    ///    println!("{}", peer);
+    ///    println!("{:?}", peer);
     /// }
     /// ```
     pub fn get_peers(&self) -> Result<Vec<BrokerPeer>, BrokerError> {

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -1,0 +1,29 @@
+use chrono::NaiveDate;
+use serde::{Deserialize, Serialize};
+use std::net::IpAddr;
+
+/// MRT collector peer information
+///
+/// Represents the information of an MRT collector peer.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+pub struct BrokerPeer {
+    /// The date of the latest available data.
+    pub date: NaiveDate,
+    /// The IP address of the collector peer.
+    pub ip: IpAddr,
+    /// The ASN (Autonomous System Number) of the collector peer.
+    pub asn: u32,
+    /// The name of the collector.
+    pub collector: String,
+    /// The number of IPv4 prefixes.
+    pub num_v4_pfxs: u32,
+    /// The number of IPv6 prefixes.
+    pub num_v6_pfxs: u32,
+    /// The number of connected ASNs.
+    pub num_connected_asns: u32,
+}
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub(crate) struct BrokerPeersResult {
+    pub count: u32,
+    pub data: Vec<BrokerPeer>,
+}

--- a/src/peer.rs
+++ b/src/peer.rs
@@ -6,6 +6,7 @@ use std::net::IpAddr;
 ///
 /// Represents the information of an MRT collector peer.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
+#[cfg_attr(feature = "cli", derive(tabled::Tabled))]
 pub struct BrokerPeer {
     /// The date of the latest available data.
     pub date: NaiveDate,

--- a/src/query.rs
+++ b/src/query.rs
@@ -2,6 +2,7 @@
 use crate::BrokerItem;
 use serde::{Deserialize, Serialize};
 use std::fmt::{Display, Formatter};
+use std::net::IpAddr;
 
 /// QueryParams represents the query parameters to the backend API.
 ///
@@ -41,6 +42,12 @@ pub struct QueryParams {
     pub page: i64,
     /// number of items each page contains, default to 10, max to 100000
     pub page_size: i64,
+    /// collector peer IP address (for listing peers info)
+    pub peers_ip: Option<IpAddr>,
+    /// collector peer ASN (for listing peers info)
+    pub peers_asn: Option<u32>,
+    /// collector peer full feed status (for listing peers info)
+    pub peers_only_full_feed: bool,
 }
 
 /// Sorting order enum
@@ -63,6 +70,9 @@ impl Default for QueryParams {
             data_type: None,
             page: 1,
             page_size: 100,
+            peers_ip: None,
+            peers_asn: None,
+            peers_only_full_feed: false,
         }
     }
 }
@@ -119,6 +129,7 @@ impl QueryParams {
             data_type: None,
             page: 1,
             page_size: 10,
+            ..Default::default()
         }
     }
 
@@ -250,7 +261,7 @@ pub(crate) struct CollectorLatestResult {
 
 /// Query result struct that contains data or error message
 #[derive(Debug, Serialize, Deserialize)]
-pub(crate) struct QueryResult {
+pub(crate) struct BrokerQueryResult {
     /// number of items returned in **current** call
     pub count: Option<i64>,
     /// the page number of the current call
@@ -263,7 +274,7 @@ pub(crate) struct QueryResult {
     pub data: Vec<BrokerItem>,
 }
 
-impl Display for QueryResult {
+impl Display for BrokerQueryResult {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", serde_json::to_string(self).unwrap())
     }
@@ -283,6 +294,7 @@ mod tests {
             data_type: None,
             page: 1,
             page_size: 20,
+            ..Default::default()
         };
 
         assert_eq!(
@@ -298,6 +310,7 @@ mod tests {
             data_type: None,
             page: 1,
             page_size: 20,
+            ..Default::default()
         };
 
         assert_eq!("?page=1&page_size=20".to_string(), param.to_string());


### PR DESCRIPTION
* migrate default broker API endpoint to `https://api.bgpkit.com/v3/broker`
    * Full API docs is available at `https://api.bgpkit.com/docs`
* add `get_peers` to `BgpkitBroker` struct
    * fetches the list of peers for a given collector
    * can specify filters the same way as querying MRT files
    * available filter functions include:
        * `.peers_asn(ASN)`
        * `.peers_ip(IP)`
        * `.collector_id(COLLECTOR_ID)`
        * `.peers_only_full_feed(TRUE/FALSE)`
    * returns `Vec<BrokerPeer>`

```rust
#[derive(Debug, Clone, Eq, PartialEq, Serialize, Deserialize)]
pub struct BrokerPeer {
    /// The date of the latest available data.
    pub date: NaiveDate,
    /// The IP address of the collector peer.
    pub ip: IpAddr,
    /// The ASN (Autonomous System Number) of the collector peer.
    pub asn: u32,
    /// The name of the collector.
    pub collector: String,
    /// The number of IPv4 prefixes.
    pub num_v4_pfxs: u32,
    /// The number of IPv6 prefixes.
    pub num_v6_pfxs: u32,
    /// The number of connected ASNs.
    pub num_connected_asns: u32,
}
```