### PR TITLE
Run analyze on database periodically

### DIFF
--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -321,7 +321,9 @@ impl LocalBrokerDb {
     /// * `Ok(())` - If the analyze operation executed successfully.
     /// * `Err(BrokerError)` - If an error occurred during the execution of the analyze command.
     pub async fn analyze(&self) -> Result<(), BrokerError> {
+        info!("doing sqlite3 analyze...");
         sqlx::query("ANALYZE").execute(&self.conn_pool).await?;
+        info!("doing sqlite3 analyze...done");
         Ok(())
     }
 

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -311,6 +311,20 @@ impl LocalBrokerDb {
         Ok(items)
     }
 
+    /// Runs the SQLite `ANALYZE` command on the database connection pool.
+    ///
+    /// This method updates SQLite's internal statistics used for query planning,
+    /// helping to optimize database query performance.
+    ///
+    /// # Returns
+    ///
+    /// * `Ok(())` - If the analyze operation executed successfully.
+    /// * `Err(BrokerError)` - If an error occurred during the execution of the analyze command.
+    pub async fn analyze(&self) -> Result<(), BrokerError> {
+        sqlx::query("ANALYZE").execute(&self.conn_pool).await?;
+        Ok(())
+    }
+
     /// Inserts a batch of items into the files table.
     ///
     /// # Arguments


### PR DESCRIPTION
SQLite ANALYZE should be run periodically to ensure the performance is stable. This is especially true after a long period of time with large number of insertions.

Related issue: #67 