### PR TITLE
feat: add opt-in PostgreSQL backend

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 # flyctl launch added from .gitignore
 target
-**/Cargo.lock
 **/.idea
 
 **/*.sqlite3*

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@
 *wal
 *.duckdb*
 *.parquet
+__pycache__/
+*.py[cod]
 /.env
 .claude
 CLAUDE.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3040,6 +3040,7 @@ dependencies = [
  "base64",
  "bytes",
  "cfg-if",
+ "chrono",
  "crc",
  "crossbeam-queue",
  "either",
@@ -3113,6 +3114,7 @@ dependencies = [
  "bitflags 2.13.0",
  "byteorder",
  "bytes",
+ "chrono",
  "crc",
  "digest 0.11.3",
  "dotenvy",
@@ -3140,6 +3142,7 @@ dependencies = [
  "base64",
  "bitflags 2.13.0",
  "byteorder",
+ "chrono",
  "crc",
  "dotenvy",
  "etcetera",
@@ -3172,6 +3175,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488e99c397a62007e4229aec669a179816339afc6d2620ca6fa420dbee2e982c"
 dependencies = [
  "atoi",
+ "chrono",
  "flume",
  "form_urlencoded",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,6 +73,8 @@ axum-prometheus = { version = "0.10", optional = true }
 sqlx = { version = "0.9", features = [
     "runtime-tokio",
     "sqlite",
+    "postgres",
+    "chrono",
 ], optional = true }
 
 [features]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ COPY --from=build /my_project/target/release/bgpkit-broker /usr/local/bin/bgpkit
 RUN apt update && apt install -y curl tini sqlite3
 WORKDIR /bgpkit-broker
 
-# Runtime configuration, including BGPKIT_BROKER_POSTGRES_URL, is supplied with
-# `docker run -e` or Compose. Do not bake connection URLs or credentials into the image.
+# Runtime configuration, including BGPKIT_BROKER_POSTGRES_URL and
+# BGPKIT_BROKER_SQLITE_PATH, is supplied with `docker run -e` or Compose. Do not
+# bake connection URLs or credentials into the image.
 EXPOSE 40064
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/bgpkit-broker"]
 CMD ["serve", "--bootstrap", "--silent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /my_project
 
 # copy your source tree
 COPY ./src ./src
-COPY ./Cargo.toml .
+COPY ./Cargo.toml ./Cargo.lock ./
 
 # build for release
 RUN cargo build --release --all-features
@@ -21,6 +21,8 @@ COPY --from=build /my_project/target/release/bgpkit-broker /usr/local/bin/bgpkit
 RUN apt update && apt install -y curl tini sqlite3
 WORKDIR /bgpkit-broker
 
+# Runtime configuration, including BGPKIT_BROKER_POSTGRES_URL, is supplied with
+# `docker run -e` or Compose. Do not bake connection URLs or credentials into the image.
 EXPOSE 40064
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/bgpkit-broker"]
 CMD ["serve", "bgpkit-broker.sqlite3", "--bootstrap", "--silent"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,4 +25,4 @@ WORKDIR /bgpkit-broker
 # `docker run -e` or Compose. Do not bake connection URLs or credentials into the image.
 EXPOSE 40064
 ENTRYPOINT ["/usr/bin/tini", "--", "/usr/local/bin/bgpkit-broker"]
-CMD ["serve", "bgpkit-broker.sqlite3", "--bootstrap", "--silent"]
+CMD ["serve", "--bootstrap", "--silent"]

--- a/README.md
+++ b/README.md
@@ -318,7 +318,7 @@ Cache files are stored as JSON in the specified directory. The cache key is gene
 
 **Database Maintenance:**
 - `BGPKIT_BROKER_META_RETENTION_DAYS` - Number of days to retain meta entries (default: 30)
-- `BGPKIT_BROKER_POSTGRES_URL` - Explicit PostgreSQL catalog URL for the `serve` API. SQLite remains the default; PostgreSQL supports the same crawler/update lifecycle when an update-capable URL is supplied.
+- `BGPKIT_BROKER_POSTGRES_URL` - Explicit PostgreSQL catalog URL for the `serve` API. SQLite remains the default; PostgreSQL supports the same crawler/update lifecycle when an update-capable URL is supplied. Initialize a new PostgreSQL catalog first with [`migration/postgres_bootstrap/bootstrap.py`](migration/postgres_bootstrap/README.md).
 
 ### Data Structures
 

--- a/README.md
+++ b/README.md
@@ -437,7 +437,6 @@ Arguments:
 
 Options:
   -i, --update-interval <UPDATE_INTERVAL>  update interval in seconds [default: 300]
-      --postgres-url <POSTGRES_URL>         explicit PostgreSQL catalog URL
       --no-log                             disable logging
   -b, --bootstrap                          bootstrap the database if it does not exist
       --env <ENV>

--- a/README.md
+++ b/README.md
@@ -319,6 +319,7 @@ Cache files are stored as JSON in the specified directory. The cache key is gene
 **Database Maintenance:**
 - `BGPKIT_BROKER_META_RETENTION_DAYS` - Number of days to retain meta entries (default: 30)
 - `BGPKIT_BROKER_POSTGRES_URL` - Explicit PostgreSQL catalog URL for the `serve` API. SQLite remains the default; PostgreSQL supports the same crawler/update lifecycle when an update-capable URL is supplied. Initialize a new PostgreSQL catalog first with [`migration/postgres_bootstrap/bootstrap.py`](migration/postgres_bootstrap/README.md).
+- `BGPKIT_BROKER_SQLITE_PATH` - SQLite catalog file path when neither a database path/URL argument nor PostgreSQL configuration is supplied. Default: `bgpkit-broker.sqlite3`.
 
 ### Data Structures
 
@@ -432,7 +433,7 @@ API endpoints. It will also periodically update the local database unless the `-
 Usage: bgpkit-broker serve [OPTIONS] [DB_PATH]
 
 Arguments:
-  [DB_PATH]  broker SQLite db file location (the default backend) [default: bgpkit-broker.sqlite3]
+  [DB_PATH]  database path or PostgreSQL URL. pg://, postgres://, and postgresql:// select PostgreSQL; other values select a SQLite file
 
 Options:
   -i, --update-interval <UPDATE_INTERVAL>  update interval in seconds [default: 300]
@@ -691,14 +692,14 @@ To run as a service using `docker compose`:
 docker compose up -d
 ```
 
-SQLite remains the default. To use PostgreSQL, initialize the catalog with
+SQLite remains the default. Set `BGPKIT_BROKER_SQLITE_PATH` to use another SQLite file. To use PostgreSQL, initialize the catalog with
 [`migration/postgres_bootstrap/bootstrap.py`](migration/postgres_bootstrap/README.md), then pass its URL only at runtime:
 
 ```bash
 BGPKIT_BROKER_POSTGRES_URL='[REDACTED]' docker compose up -d
 ```
 
-The Compose file forwards `BGPKIT_BROKER_POSTGRES_URL` without defining a database service or storing a connection URL. For `docker run`, pass the same variable with `-e BGPKIT_BROKER_POSTGRES_URL`; the image command does not override it.
+The optional `serve` database argument is also backend-agnostic: `pg://` and `postgresql://` URLs select PostgreSQL; other values are SQLite paths. The Compose file forwards both database environment variables without defining a database service or storing a connection URL. For `docker run`, pass the same variables with `-e`; the image command does not override them.
 
 You can also build the Docker image from the source code:
 

--- a/README.md
+++ b/README.md
@@ -318,6 +318,7 @@ Cache files are stored as JSON in the specified directory. The cache key is gene
 
 **Database Maintenance:**
 - `BGPKIT_BROKER_META_RETENTION_DAYS` - Number of days to retain meta entries (default: 30)
+- `BGPKIT_BROKER_POSTGRES_URL` - Explicit PostgreSQL catalog URL for the `serve` API. SQLite remains the default; PostgreSQL supports the same crawler/update lifecycle when an update-capable URL is supplied.
 
 ### Data Structures
 
@@ -428,13 +429,14 @@ API endpoints. It will also periodically update the local database unless the `-
 ```text
   Serve the Broker content via RESTful API
 
-Usage: bgpkit-broker serve [OPTIONS] <DB_PATH>
+Usage: bgpkit-broker serve [OPTIONS] [DB_PATH]
 
 Arguments:
-  <DB_PATH>  broker db file location
+  [DB_PATH]  broker SQLite db file location (the default backend) [default: bgpkit-broker.sqlite3]
 
 Options:
   -i, --update-interval <UPDATE_INTERVAL>  update interval in seconds [default: 300]
+      --postgres-url <POSTGRES_URL>         explicit PostgreSQL catalog URL
       --no-log                             disable logging
   -b, --bootstrap                          bootstrap the database if it does not exist
       --env <ENV>

--- a/README.md
+++ b/README.md
@@ -320,6 +320,7 @@ Cache files are stored as JSON in the specified directory. The cache key is gene
 - `BGPKIT_BROKER_META_RETENTION_DAYS` - Number of days to retain meta entries (default: 30)
 - `BGPKIT_BROKER_POSTGRES_URL` - Explicit PostgreSQL catalog URL for the `serve` API. SQLite remains the default; PostgreSQL supports the same crawler/update lifecycle when an update-capable URL is supplied. Initialize a new PostgreSQL catalog first with [`migration/postgres_bootstrap/bootstrap.py`](migration/postgres_bootstrap/README.md).
 - `BGPKIT_BROKER_SQLITE_PATH` - SQLite catalog file path when neither a database path/URL argument nor PostgreSQL configuration is supplied. Default: `bgpkit-broker.sqlite3`.
+- `BGPKIT_BROKER_POSTGRES_MAX_CONNECTIONS` - Maximum number of connections in the PostgreSQL pool (default: 10).
 
 ### Data Structures
 

--- a/README.md
+++ b/README.md
@@ -685,11 +685,20 @@ To run in deattached mode (as a service):
 docker run -d -p 40064:40064 bgpkit/bgpkit-broker:latest
 ```
 
-To run as a service using `docker-compose`:
+To run as a service using `docker compose`:
 
-``` bash
-docker-compose up -d
+```bash
+docker compose up -d
 ```
+
+SQLite remains the default. To use PostgreSQL, initialize the catalog with
+[`migration/postgres_bootstrap/bootstrap.py`](migration/postgres_bootstrap/README.md), then pass its URL only at runtime:
+
+```bash
+BGPKIT_BROKER_POSTGRES_URL='[REDACTED]' docker compose up -d
+```
+
+The Compose file forwards `BGPKIT_BROKER_POSTGRES_URL` without defining a database service or storing a connection URL. For `docker run`, pass the same variable with `-e BGPKIT_BROKER_POSTGRES_URL`; the image command does not override it.
 
 You can also build the Docker image from the source code:
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -6,7 +6,9 @@ services:
     volumes:
       - ./data:/bgpkit-broker
     environment:
-      # Empty keeps the SQLite default. Set this runtime variable to select a
-      # pre-initialized PostgreSQL catalog; do not commit the value.
+      # Empty values keep the built-in SQLite path. Set one runtime variable to
+      # select a pre-initialized PostgreSQL catalog or custom SQLite file; do not
+      # commit PostgreSQL connection values.
       BGPKIT_BROKER_POSTGRES_URL: ${BGPKIT_BROKER_POSTGRES_URL:-}
+      BGPKIT_BROKER_SQLITE_PATH: ${BGPKIT_BROKER_SQLITE_PATH:-}
     restart: unless-stopped

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: "3.8"
 services:
   bgpkit-broker:
     image: bgpkit/bgpkit-broker:latest
@@ -6,4 +5,8 @@ services:
       - "40064:40064"
     volumes:
       - ./data:/bgpkit-broker
+    environment:
+      # Empty keeps the SQLite default. Set this runtime variable to select a
+      # pre-initialized PostgreSQL catalog; do not commit the value.
+      BGPKIT_BROKER_POSTGRES_URL: ${BGPKIT_BROKER_POSTGRES_URL:-}
     restart: unless-stopped

--- a/migration/postgres_bootstrap/README.md
+++ b/migration/postgres_bootstrap/README.md
@@ -1,0 +1,68 @@
+# Broker SQLite → PostgreSQL bootstrap
+
+This utility imports a Broker SQLite catalog into PostgreSQL and creates a Broker-compatible catalog:
+
+- `mrt`: RouteViews/RIPE RIS collectors, archive-file observations, latest-file read model, and crawler update metadata;
+- `api`: Broker-compatible search/latest views.
+
+It indexes archive metadata only. Raw MRT payloads stay in archive/object storage. `mrt.file` is an observed catalog entry, not a reachability or routing-forwarding claim.
+
+## Data model
+
+The PostgreSQL schema deliberately mirrors Broker’s operational model rather than adding a separate ingestion-provenance layer:
+
+- `mrt.file` holds one catalog entry per `(timestamp, collector, type)`;
+- `mrt.latest_file` is the newest entry per collector/type and is refreshed after a bootstrap or incrementally maintained by the crawler;
+- `mrt.update_meta` mirrors SQLite’s `meta` table: update timestamp, crawler duration, and inserted-row count.
+
+The importer preserves zero sizes (`0` remains `0`); it does not reinterpret zero as unknown.
+
+The compatibility view is `api.mrt_file_search`:
+
+| SQLite `files_view` | PostgreSQL view |
+|---|---|
+| `timestamp` | `timestamp` (`timestamptz`) |
+| `type` | `type` |
+| `collector_name`, `collector_url`, `project_name` | same names |
+| `rough_size`, `exact_size`, `updates_interval` | same names |
+
+## Bootstrap
+
+```bash
+python3 migration/postgres_bootstrap/bootstrap.py \
+  /var/lib/bgpkit/broker/bgpkit_broker.sqlite3 \
+  --database-url "$POSTGRES_URL" \
+  --batch-size 100000 --reset
+```
+
+`--reset` drops and recreates only the `api` and `mrt` schemas. Use it for a fresh catalog bootstrap, not an existing database whose catalog contents must be retained.
+
+The importer exits non-zero if SQLite/PostgreSQL file or collector counts differ. It creates query indexes and runs `ANALYZE` after import.
+
+## Runtime backend selection
+
+SQLite remains the default:
+
+```bash
+bgpkit-broker serve /var/lib/bgpkit/broker/bgpkit_broker.sqlite3
+```
+
+PostgreSQL is an explicit opt-in. A single URL is the only runtime connection setting; the same configuration supports an API-only process (`--no-update`) or an API+crawler process (default):
+
+```bash
+# Prefer an environment variable or secret manager for the URL.
+export BGPKIT_BROKER_POSTGRES_URL="$POSTGRES_URL"
+bgpkit-broker serve
+
+# Explicit CLI URL overrides the environment.
+bgpkit-broker serve --postgres-url "$POSTGRES_URL"
+
+# API-only deployment: disable the updater.
+bgpkit-broker serve --postgres-url "$POSTGRES_URL" --no-update
+```
+
+The runtime dispatches through `DatabaseBackend`: `LocalBrokerDb` for SQLite and `PostgresDb` for PostgreSQL. SQLite file backups are intentionally skipped for PostgreSQL deployments; use PostgreSQL-native backup/replication instead. No credential is stored in this repository.
+
+## Scope boundary
+
+The schema/catalogue indexes archive metadata only. Raw MRT payloads remain in archive/object storage.

--- a/migration/postgres_bootstrap/README.md
+++ b/migration/postgres_bootstrap/README.md
@@ -51,14 +51,14 @@ PostgreSQL is an explicit opt-in. A single URL is the only runtime connection se
 
 ```bash
 # Prefer an environment variable or secret manager for the URL.
-export BGPKIT_BROKER_POSTGRES_URL="$POSTGRES_URL"
-bgpkit-broker serve
+# Combined crawler + API service using the environment selector.
+BGPKIT_BROKER_POSTGRES_URL="$POSTGRES_URL" bgpkit-broker serve
 
-# Explicit CLI URL overrides the environment.
-bgpkit-broker serve --postgres-url "$POSTGRES_URL"
+# Or pass a PostgreSQL URL as the database target.
+bgpkit-broker serve "pg://broker@db.example/broker"
 
 # API-only deployment: disable the updater.
-bgpkit-broker serve --postgres-url "$POSTGRES_URL" --no-update
+BGPKIT_BROKER_POSTGRES_URL="$POSTGRES_URL" bgpkit-broker serve --no-update
 ```
 
 The runtime dispatches through `DatabaseBackend`: `LocalBrokerDb` for SQLite and `PostgresDb` for PostgreSQL. SQLite file backups are intentionally skipped for PostgreSQL deployments; use PostgreSQL-native backup/replication instead. No credential is stored in this repository.

--- a/migration/postgres_bootstrap/bootstrap.py
+++ b/migration/postgres_bootstrap/bootstrap.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""Bootstrap the PostgreSQL Broker catalog from SQLite."""
+
+import argparse
+from datetime import datetime, timezone
+from pathlib import Path
+import sqlite3
+import sys
+from typing import Iterator
+
+
+BATCH_SIZE = 100_000
+CODE_VERSION = "postgres-bootstrap-poc-v1"
+
+
+def project_name(value: str) -> str:
+    normalized = value.lower().replace("_", "-")
+    aliases = {"riperis": "ripe-ris", "ripe-ris": "ripe-ris", "routeviews": "route-views", "route-views": "route-views"}
+    try:
+        return aliases[normalized]
+    except KeyError as error:
+        raise ValueError(f"unknown legacy Broker project: {value!r}") from error
+
+
+def copy_row(row: tuple, collector_ids: dict[int, int], types: dict[int, str]) -> tuple:
+    ts_epoch, old_collector_id, old_type_id, rough_size, exact_size = row
+    try:
+        collector_id = collector_ids[old_collector_id]
+        data_type = types[old_type_id]
+    except KeyError as error:
+        raise ValueError(f"unmapped legacy foreign key: {error.args[0]}") from error
+    if data_type not in {"rib", "updates"}:
+        raise ValueError(f"unknown legacy Broker type: {data_type!r}")
+    return ts_epoch, collector_id, data_type, rough_size, exact_size
+
+
+def sqlite_connection(path: Path) -> sqlite3.Connection:
+    connection = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    connection.execute("PRAGMA query_only = ON")
+    return connection
+
+
+def ensure_sqlite_shape(connection: sqlite3.Connection) -> None:
+    required = {"collectors", "types", "files", "meta"}
+    actual = {row[0] for row in connection.execute("SELECT name FROM sqlite_master WHERE type = 'table'")}
+    missing = required - actual
+    if missing:
+        raise ValueError(f"SQLite source is not a Broker database; missing tables: {', '.join(sorted(missing))}")
+
+
+def schema_sql() -> str:
+    return (Path(__file__).parent / "schema.sql").read_text(encoding="utf-8")
+
+
+def execute_schema(connection, reset: bool) -> None:
+    with connection.cursor() as cursor:
+        if reset:
+            cursor.execute("DROP SCHEMA IF EXISTS api CASCADE; DROP SCHEMA IF EXISTS mrt CASCADE;")
+        cursor.execute(schema_sql())
+    connection.commit()
+
+
+def import_collectors(sqlite_db: sqlite3.Connection, pg) -> tuple[dict[int, int], dict[int, str]]:
+    with pg.cursor() as cursor:
+        for name in ("ripe-ris", "route-views"):
+            cursor.execute("INSERT INTO mrt.project (name) VALUES (%s) ON CONFLICT DO NOTHING", (name,))
+
+        project_ids = dict(cursor.execute("SELECT name, project_id FROM mrt.project").fetchall())
+        collector_ids: dict[int, int] = {}
+        for legacy_id, name, url, project, interval in sqlite_db.execute(
+            "SELECT id, name, url, project, updates_interval FROM collectors WHERE name IS NOT NULL ORDER BY id"
+        ):
+            normalized_project = project_name(project)
+            cursor.execute(
+                """
+                INSERT INTO mrt.collector (project_id, name, base_uri, updates_interval_seconds)
+                VALUES (%s, %s, %s, %s)
+                ON CONFLICT (project_id, name) DO UPDATE
+                    SET base_uri = EXCLUDED.base_uri,
+                        updates_interval_seconds = EXCLUDED.updates_interval_seconds
+                RETURNING collector_id
+                """,
+                (project_ids[normalized_project], name, url, interval),
+            )
+            collector_ids[legacy_id] = cursor.fetchone()[0]
+        types = dict(sqlite_db.execute("SELECT id, name FROM types").fetchall())
+    pg.commit()
+    return collector_ids, types
+
+
+def batches(cursor: sqlite3.Cursor, batch_size: int) -> Iterator[list[tuple]]:
+    while rows := cursor.fetchmany(batch_size):
+        yield rows
+
+
+def copy_files(sqlite_db: sqlite3.Connection, pg, collector_ids: dict[int, int], types: dict[int, str], batch_size: int) -> tuple[int, int]:
+    source = sqlite_db.cursor()
+    source.execute("SELECT timestamp, collector_id, type_id, rough_size, exact_size FROM files ORDER BY timestamp, collector_id, type_id")
+    seen = inserted = 0
+    for batch in batches(source, batch_size):
+        converted = [copy_row(row, collector_ids, types) for row in batch]
+        with pg.cursor() as cursor:
+            cursor.execute("CREATE TEMP TABLE broker_file_stage (ts_epoch BIGINT, collector_id BIGINT, data_type TEXT, rough_size BIGINT, exact_size BIGINT) ON COMMIT DROP")
+            with cursor.copy("COPY broker_file_stage (ts_epoch, collector_id, data_type, rough_size, exact_size) FROM STDIN") as copy:
+                for row in converted:
+                    copy.write_row(row)
+            cursor.execute(
+                """
+                INSERT INTO mrt.file (ts_start, collector_id, data_type, rough_size, exact_size)
+                SELECT to_timestamp(ts_epoch), collector_id, data_type, rough_size, exact_size
+                FROM broker_file_stage
+                ON CONFLICT (ts_start, collector_id, data_type) DO NOTHING
+                """
+            )
+            inserted += cursor.rowcount
+        pg.commit()
+        seen += len(converted)
+        print(f"  files: {seen:,} seen / {inserted:,} inserted", flush=True)
+    return seen, inserted
+
+
+def refresh_latest(pg) -> int:
+    with pg.cursor() as cursor:
+        cursor.execute("TRUNCATE mrt.latest_file")
+        cursor.execute(
+            """
+            INSERT INTO mrt.latest_file
+                (collector_id, data_type, ts_start, rough_size, exact_size)
+            SELECT DISTINCT ON (collector_id, data_type)
+                collector_id, data_type, ts_start, rough_size, exact_size
+            FROM mrt.file
+            ORDER BY collector_id, data_type, ts_start DESC
+            """
+        )
+        count = cursor.rowcount
+    pg.commit()
+    return count
+
+
+def import_update_meta(sqlite_db: sqlite3.Connection, pg) -> int:
+    rows = list(sqlite_db.execute("SELECT update_ts, update_duration, insert_count FROM meta"))
+    if not rows:
+        return 0
+    with pg.cursor() as cursor:
+        cursor.execute("TRUNCATE mrt.update_meta")
+        with cursor.copy(
+            "COPY mrt.update_meta (update_ts, update_duration_seconds, insert_count) FROM STDIN"
+        ) as copy:
+            for update_ts, duration, inserts in rows:
+                copy.write_row((datetime.fromtimestamp(update_ts, timezone.utc), duration, inserts))
+    pg.commit()
+    return len(rows)
+
+
+def create_indexes(pg) -> None:
+    with pg.cursor() as cursor:
+        cursor.execute("CREATE INDEX IF NOT EXISTS mrt_file_collector_type_ts_idx ON mrt.file (collector_id, data_type, ts_start)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS mrt_file_type_ts_idx ON mrt.file (data_type, ts_start)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS mrt_update_meta_ts_idx ON mrt.update_meta (update_ts DESC)")
+        cursor.execute("ANALYZE mrt.file; ANALYZE mrt.collector; ANALYZE mrt.latest_file")
+    pg.commit()
+
+
+def verify(sqlite_db: sqlite3.Connection, pg) -> None:
+    sqlite_files = sqlite_db.execute("SELECT COUNT(*) FROM files").fetchone()[0]
+    sqlite_collectors = sqlite_db.execute("SELECT COUNT(*) FROM collectors WHERE name IS NOT NULL").fetchone()[0]
+    with pg.cursor() as cursor:
+        cursor.execute("SELECT COUNT(*), min(ts_start), max(ts_start) FROM mrt.file")
+        pg_files, minimum, maximum = cursor.fetchone()
+        cursor.execute("SELECT COUNT(*) FROM mrt.collector")
+        pg_collectors = cursor.fetchone()[0]
+        cursor.execute("SELECT COUNT(*) FROM mrt.latest_file")
+        latest = cursor.fetchone()[0]
+    if sqlite_files != pg_files or sqlite_collectors != pg_collectors:
+        raise RuntimeError(f"verification failed: SQLite files/collectors={sqlite_files}/{sqlite_collectors}; PostgreSQL={pg_files}/{pg_collectors}")
+    print(f"verified: files={pg_files:,}, collectors={pg_collectors}, latest={latest}, time_range={minimum}..{maximum}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("sqlite_path", type=Path)
+    parser.add_argument("--database-url", required=True, help="libpq URL, normally postgresql:///bgpkit_platform?host=/var/run/postgresql")
+    parser.add_argument("--batch-size", type=int, default=BATCH_SIZE)
+    parser.add_argument("--reset", action="store_true", help="drop only api and mrt schemas before import")
+    args = parser.parse_args()
+    if args.batch_size < 1:
+        parser.error("--batch-size must be positive")
+
+    try:
+        import psycopg
+        sqlite_db = sqlite_connection(args.sqlite_path)
+        ensure_sqlite_shape(sqlite_db)
+        with psycopg.connect(args.database_url) as pg:
+            execute_schema(pg, args.reset)
+            collector_ids, types = import_collectors(sqlite_db, pg)
+            seen, inserted = copy_files(sqlite_db, pg, collector_ids, types, args.batch_size)
+            latest = refresh_latest(pg)
+            imported_meta = import_update_meta(sqlite_db, pg)
+            create_indexes(pg)
+            verify(sqlite_db, pg)
+            print(f"completed: latest={latest}, update_meta={imported_meta}, files_seen={seen}, files_inserted={inserted}")
+    except Exception as error:
+        print(f"bootstrap failed: {error}", file=sys.stderr)
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/migration/postgres_bootstrap/schema.sql
+++ b/migration/postgres_bootstrap/schema.sql
@@ -1,0 +1,74 @@
+-- PostgreSQL catalog backing the BGPKIT Broker API.
+-- Raw MRT payloads remain in archive/object storage; this database indexes metadata.
+
+CREATE SCHEMA IF NOT EXISTS mrt;
+CREATE SCHEMA IF NOT EXISTS api;
+
+CREATE TABLE IF NOT EXISTS mrt.project (
+    project_id SMALLINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    name TEXT NOT NULL UNIQUE CHECK (name IN ('ripe-ris', 'route-views'))
+);
+
+CREATE TABLE IF NOT EXISTS mrt.collector (
+    collector_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    project_id SMALLINT NOT NULL REFERENCES mrt.project(project_id),
+    name TEXT NOT NULL,
+    base_uri TEXT NOT NULL,
+    updates_interval_seconds INTEGER NOT NULL CHECK (updates_interval_seconds > 0),
+    UNIQUE (project_id, name)
+);
+
+-- One row is an observed archive object catalog entry, not a guarantee of reachability.
+CREATE TABLE IF NOT EXISTS mrt.file (
+    ts_start TIMESTAMPTZ NOT NULL,
+    collector_id BIGINT NOT NULL REFERENCES mrt.collector(collector_id),
+    data_type TEXT NOT NULL CHECK (data_type IN ('rib', 'updates')),
+    rough_size BIGINT NOT NULL DEFAULT 0 CHECK (rough_size >= 0),
+    exact_size BIGINT NOT NULL DEFAULT 0 CHECK (exact_size >= 0),
+    PRIMARY KEY (ts_start, collector_id, data_type)
+);
+
+-- Compatibility/read model: refreshed after each complete ingest.
+CREATE TABLE IF NOT EXISTS mrt.latest_file (
+    collector_id BIGINT NOT NULL REFERENCES mrt.collector(collector_id),
+    data_type TEXT NOT NULL CHECK (data_type IN ('rib', 'updates')),
+    ts_start TIMESTAMPTZ NOT NULL,
+    rough_size BIGINT NOT NULL DEFAULT 0,
+    exact_size BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (collector_id, data_type)
+);
+
+-- Mirrors the SQLite Broker `meta` table for operational update status.
+CREATE TABLE IF NOT EXISTS mrt.update_meta (
+    update_ts TIMESTAMPTZ NOT NULL,
+    update_duration_seconds INTEGER NOT NULL,
+    insert_count INTEGER NOT NULL
+);
+
+CREATE OR REPLACE VIEW api.mrt_file_search AS
+SELECT
+    f.ts_start AS timestamp,
+    f.rough_size,
+    f.exact_size,
+    f.data_type AS type,
+    c.name AS collector_name,
+    c.base_uri AS collector_url,
+    p.name AS project_name,
+    c.updates_interval_seconds AS updates_interval
+FROM mrt.file AS f
+JOIN mrt.collector AS c USING (collector_id)
+JOIN mrt.project AS p USING (project_id);
+
+CREATE OR REPLACE VIEW api.mrt_file_latest AS
+SELECT
+    l.ts_start AS timestamp,
+    l.rough_size,
+    l.exact_size,
+    l.data_type AS type,
+    c.name AS collector_name,
+    c.base_uri AS collector_url,
+    p.name AS project_name,
+    c.updates_interval_seconds AS updates_interval
+FROM mrt.latest_file AS l
+JOIN mrt.collector AS c USING (collector_id)
+JOIN mrt.project AS p USING (project_id);

--- a/migration/postgres_bootstrap/tests/test_bootstrap.py
+++ b/migration/postgres_bootstrap/tests/test_bootstrap.py
@@ -1,0 +1,43 @@
+import importlib.util
+from pathlib import Path
+import unittest
+
+
+MODULE_PATH = Path(__file__).parents[1] / "bootstrap.py"
+SPEC = importlib.util.spec_from_file_location("broker_postgres_bootstrap", MODULE_PATH)
+if SPEC is None or SPEC.loader is None:
+    raise RuntimeError(f"unable to load {MODULE_PATH}")
+bootstrap = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(bootstrap)
+
+
+class BootstrapHelpersTests(unittest.TestCase):
+    def test_project_name_normalizes_legacy_broker_values(self):
+        self.assertEqual(bootstrap.project_name("riperis"), "ripe-ris")
+        self.assertEqual(bootstrap.project_name("routeviews"), "route-views")
+
+    def test_project_name_rejects_unknown_values(self):
+        with self.assertRaises(ValueError):
+            bootstrap.project_name("other")
+
+    def test_copy_row_preserves_zero_sizes_from_sqlite(self):
+        self.assertEqual(
+            bootstrap.copy_row((1704067200, 7, 2, 0, 1234), {7: 11}, {2: "rib"}),
+            (1704067200, 11, "rib", 0, 1234),
+        )
+
+    def test_copy_row_rejects_unmapped_collector_or_type(self):
+        with self.assertRaises(ValueError):
+            bootstrap.copy_row((1704067200, 7, 2, 0, 1234), {}, {2: "rib"})
+        with self.assertRaises(ValueError):
+            bootstrap.copy_row((1704067200, 7, 2, 0, 1234), {7: 11}, {})
+
+    def test_schema_uses_operational_update_metadata_without_provenance_tables(self):
+        schema = bootstrap.schema_sql()
+        self.assertIn("CREATE TABLE IF NOT EXISTS mrt.update_meta", schema)
+        self.assertNotIn("meta.source_revision", schema)
+        self.assertNotIn("meta.ingest_run", schema)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -5,7 +5,9 @@ use axum::response::IntoResponse;
 use axum::routing::get;
 use axum::{Json, Router};
 use axum_prometheus::PrometheusMetricLayerBuilder;
-use bgpkit_broker::{BrokerItem, LocalBrokerDb, DEFAULT_PAGE_SIZE};
+#[cfg(test)]
+use bgpkit_broker::LocalBrokerDb;
+use bgpkit_broker::{BrokerItem, DatabaseBackend, DEFAULT_PAGE_SIZE};
 use chrono::{DateTime, NaiveDate, NaiveDateTime};
 use clap::Args;
 use futures::stream;
@@ -23,7 +25,7 @@ use tracing::{info, warn};
 pub(crate) const LIVE_EVENT_BUFFER_SIZE: usize = 4096;
 
 struct AppState {
-    database: LocalBrokerDb,
+    database: DatabaseBackend,
     live_events: broadcast::Sender<BrokerItem>,
     updater_enabled: bool,
 }
@@ -451,7 +453,7 @@ fn parse_time_str(ts_str: &str) -> Result<NaiveDateTime, String> {
 }
 
 pub async fn start_api_service(
-    database: LocalBrokerDb,
+    database: DatabaseBackend,
     live_events: broadcast::Sender<BrokerItem>,
     updater_enabled: bool,
     host: String,
@@ -524,15 +526,16 @@ mod tests {
         }
     }
 
-    async fn test_database() -> (tempfile::TempDir, LocalBrokerDb) {
+    async fn test_database() -> (tempfile::TempDir, DatabaseBackend) {
         let dir = tempdir().unwrap();
         let path = dir.path().join("test.sqlite3");
-        let database = LocalBrokerDb::new(path.to_str().unwrap()).await.unwrap();
+        let database =
+            DatabaseBackend::Sqlite(LocalBrokerDb::new(path.to_str().unwrap()).await.unwrap());
         (dir, database)
     }
 
     fn test_router(
-        database: LocalBrokerDb,
+        database: DatabaseBackend,
         live_events: broadcast::Sender<BrokerItem>,
         updater_enabled: bool,
         root: &str,

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -10,7 +10,7 @@ use crate::bootstrap::download_file;
 use crate::utils::{get_missing_collectors, is_local_path, parse_s3_path};
 use bgpkit_broker::{
     crawl_collector, load_collectors, BgpkitBroker, BrokerConfig, BrokerError, BrokerItem,
-    Collector, LocalBrokerDb, DEFAULT_PAGE_SIZE,
+    Collector, DatabaseBackend, DatabaseTarget, LocalBrokerDb, DEFAULT_PAGE_SIZE,
 };
 use chrono::{Duration, NaiveDateTime, Utc};
 use clap::{Parser, Subcommand};
@@ -46,8 +46,13 @@ const BOOTSTRAP_URL: &str = "https://spaces.bgpkit.org/broker/bgpkit_broker.sqli
 enum Commands {
     /// Serve the Broker content via RESTful API
     Serve {
-        /// broker db file location
+        /// broker SQLite db file location (the default backend)
+        #[clap(default_value = "bgpkit-broker.sqlite3")]
         db_path: String,
+
+        /// Explicit PostgreSQL connection URL. Takes precedence over SQLite and can also be set with BGPKIT_BROKER_POSTGRES_URL.
+        #[clap(long)]
+        postgres_url: Option<String>,
 
         /// update interval in seconds
         #[clap(short = 'i', long, default_value = "300", value_parser = min_update_interval_check)]
@@ -285,7 +290,7 @@ struct UpdateContext<'a> {
 
 /// update the database with data crawled from the given collectors
 async fn update_database(
-    db: &mut LocalBrokerDb,
+    db: &mut DatabaseBackend,
     collectors: Vec<Collector>,
     days: Option<u32>,
     context: UpdateContext<'_>,
@@ -316,7 +321,9 @@ async fn update_database(
     }
     if collector_updated {
         info!("collector list updated, reload collectors list into memory");
-        db.reload_collectors().await;
+        if let Err(e) = db.reload_collectors().await {
+            error!("failed to reload collectors: {}", e);
+        }
     }
 
     let collector_concurrency = context.config.crawler.collector_concurrency;
@@ -373,7 +380,10 @@ async fn update_database(
     }
 
     // Cleanup old meta entries
-    if let Err(e) = db.cleanup_old_meta_entries().await {
+    if let Err(e) = db
+        .cleanup_old_meta_entries(context.config.database.meta_retention_days)
+        .await
+    {
         error!("failed to cleanup old meta entries: {}", e);
     }
 
@@ -438,6 +448,31 @@ fn display_configuration_summary(
     }
 }
 
+fn resolve_database_target(
+    sqlite_path: &str,
+    postgres_url: Option<&str>,
+    config: &BrokerConfig,
+) -> DatabaseTarget {
+    match DatabaseTarget::resolve(
+        Some(sqlite_path),
+        postgres_url
+            .filter(|url| !url.trim().is_empty())
+            .or_else(|| {
+                config
+                    .database
+                    .postgres_url
+                    .as_deref()
+                    .filter(|url| !url.trim().is_empty())
+            }),
+    ) {
+        Ok(target) => target,
+        Err(e) => {
+            error!("database configuration error: {}", e);
+            exit(1);
+        }
+    }
+}
+
 fn main() {
     dotenvy::dotenv().ok();
 
@@ -464,6 +499,7 @@ fn main() {
     match cli.command {
         Commands::Serve {
             db_path,
+            postgres_url,
             update_interval,
             bootstrap,
             silent,
@@ -481,7 +517,8 @@ fn main() {
 
             // Load configuration from environment variables
             let config = BrokerConfig::from_env();
-
+            let database_target =
+                resolve_database_target(&db_path, postgres_url.as_deref(), &config);
             // Display configuration summary
             if do_log {
                 display_configuration_summary(
@@ -494,7 +531,9 @@ fn main() {
                 );
             }
 
-            if std::fs::metadata(&db_path).is_err() {
+            if matches!(database_target, DatabaseTarget::Sqlite(_))
+                && std::fs::metadata(&db_path).is_err()
+            {
                 if bootstrap {
                     // bootstrap the database
                     let rt = get_tokio_runtime();
@@ -530,7 +569,11 @@ fn main() {
 
             if do_update {
                 // starting a new dedicated thread to periodically fetch new data from collectors
-                let path = db_path.clone();
+                let database_target_clone = database_target.clone();
+                let sqlite_backup_path = match &database_target {
+                    DatabaseTarget::Sqlite(path) => Some(path.clone()),
+                    DatabaseTarget::Postgres(_) => None,
+                };
                 let backup_to = std::env::var("BGPKIT_BROKER_BACKUP_TO").ok();
                 let backup_to_clone = backup_to.clone();
                 let config_clone = config.clone();
@@ -546,7 +589,7 @@ fn main() {
                         }
                     };
                     rt.block_on(async {
-                        let mut db = match LocalBrokerDb::new(path.as_str()).await {
+                        let mut db = match DatabaseBackend::connect(&database_target_clone).await {
                             Ok(db) => db,
                             Err(e) => {
                                 error!("failed to open database: {}", e);
@@ -585,9 +628,11 @@ fn main() {
                         }
 
                         // perform initial backup if configured
-                        if let Some(ref backup_destination) = backup_to_clone {
+                        if let (Some(backup_destination), Some(path)) =
+                            (backup_to_clone.as_ref(), sqlite_backup_path.as_ref())
+                        {
                             info!("performing initial backup after first update...");
-                            match perform_periodic_backup(&path, backup_destination, None).await {
+                            match perform_periodic_backup(path, backup_destination, None).await {
                                 Ok(_) => {
                                     info!("initial backup completed successfully");
                                     last_backup_time = std::time::Instant::now();
@@ -626,21 +671,30 @@ fn main() {
                                 let backup_interval = config_clone.backup.interval();
 
                                 if now.duration_since(last_backup_time) >= backup_interval {
-                                    info!("starting daily backup procedure...");
-                                    match perform_periodic_backup(&path, backup_destination, None)
+                                    if let Some(path) = sqlite_backup_path.as_ref() {
+                                        info!("starting daily backup procedure...");
+                                        match perform_periodic_backup(
+                                            path,
+                                            backup_destination,
+                                            None,
+                                        )
                                         .await
-                                    {
-                                        Ok(_) => {
-                                            info!("daily backup completed successfully");
-                                            last_backup_time = now;
+                                        {
+                                            Ok(_) => {
+                                                info!("daily backup completed successfully");
+                                                last_backup_time = now;
 
-                                            // send backup heartbeat if configured
-                                            if let Err(e) = try_send_backup_heartbeat().await {
-                                                error!("failed to send backup heartbeat: {}", e);
+                                                // send backup heartbeat if configured
+                                                if let Err(e) = try_send_backup_heartbeat().await {
+                                                    error!(
+                                                        "failed to send backup heartbeat: {}",
+                                                        e
+                                                    );
+                                                }
                                             }
-                                        }
-                                        Err(e) => {
-                                            error!("daily backup failed: {}", e);
+                                            Err(e) => {
+                                                error!("daily backup failed: {}", e);
+                                            }
                                         }
                                     }
                                 }
@@ -672,7 +726,7 @@ fn main() {
                             exit(1);
                         }
                     }
-                    let database = match LocalBrokerDb::new(db_path.as_str()).await {
+                    let database = match DatabaseBackend::connect(&database_target).await {
                         Ok(db) => db,
                         Err(e) => {
                             error!("failed to open database for API: {}", e);
@@ -759,7 +813,7 @@ fn main() {
                         exit(1);
                     }
                     let mut db = match LocalBrokerDb::new(&from).await {
-                        Ok(db) => db,
+                        Ok(db) => DatabaseBackend::Sqlite(db),
                         Err(e) => {
                             error!("failed to open database: {}", e);
                             exit(1);
@@ -863,7 +917,7 @@ fn main() {
 
             rt.block_on(async {
                 let mut db = match LocalBrokerDb::new(&db_path).await {
-                    Ok(db) => db,
+                    Ok(db) => DatabaseBackend::Sqlite(db),
                     Err(e) => {
                         error!("failed to open database: {}", e);
                         exit(1);

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -46,9 +46,9 @@ const BOOTSTRAP_URL: &str = "https://spaces.bgpkit.org/broker/bgpkit_broker.sqli
 enum Commands {
     /// Serve the Broker content via RESTful API
     Serve {
-        /// broker SQLite db file location (the default backend)
-        #[clap(default_value = "bgpkit-broker.sqlite3")]
-        db_path: String,
+        /// Database path or PostgreSQL URL. A path beginning with pg://, postgres://,
+        /// or postgresql:// selects PostgreSQL; other values select a SQLite file.
+        db_path: Option<String>,
 
         /// Explicit PostgreSQL connection URL. Takes precedence over SQLite and can also be set with BGPKIT_BROKER_POSTGRES_URL.
         #[clap(long)]
@@ -449,28 +449,16 @@ fn display_configuration_summary(
 }
 
 fn resolve_database_target(
-    sqlite_path: &str,
+    database_path: Option<&str>,
     postgres_url: Option<&str>,
     config: &BrokerConfig,
 ) -> DatabaseTarget {
-    match DatabaseTarget::resolve(
-        Some(sqlite_path),
-        postgres_url
-            .filter(|url| !url.trim().is_empty())
-            .or_else(|| {
-                config
-                    .database
-                    .postgres_url
-                    .as_deref()
-                    .filter(|url| !url.trim().is_empty())
-            }),
-    ) {
-        Ok(target) => target,
-        Err(e) => {
-            error!("database configuration error: {}", e);
-            exit(1);
-        }
-    }
+    DatabaseTarget::resolve(
+        database_path,
+        postgres_url,
+        config.database.postgres_url.as_deref(),
+        config.database.sqlite_path.as_deref(),
+    )
 }
 
 fn main() {
@@ -518,7 +506,11 @@ fn main() {
             // Load configuration from environment variables
             let config = BrokerConfig::from_env();
             let database_target =
-                resolve_database_target(&db_path, postgres_url.as_deref(), &config);
+                resolve_database_target(db_path.as_deref(), postgres_url.as_deref(), &config);
+            let sqlite_path = match &database_target {
+                DatabaseTarget::Sqlite(path) => Some(path.as_str()),
+                DatabaseTarget::Postgres(_) => None,
+            };
             // Display configuration summary
             if do_log {
                 display_configuration_summary(
@@ -531,25 +523,25 @@ fn main() {
                 );
             }
 
-            if matches!(database_target, DatabaseTarget::Sqlite(_))
-                && std::fs::metadata(&db_path).is_err()
-            {
-                if bootstrap {
-                    // bootstrap the database
-                    let rt = get_tokio_runtime();
-                    let from = BOOTSTRAP_URL.to_string();
-                    rt.block_on(async {
-                        if let Err(e) = download_file(&from, &db_path, silent).await {
-                            error!("failed to download bootstrap file: {}", e);
-                            exit(1);
-                        }
-                        // The update thread will handle the first update
-                    });
-                } else {
-                    error!(
-                    "The specified database file does not exist. Consider run bootstrap command or serve command with `--bootstrap` flag."
-                );
-                    exit(1);
+            if let Some(sqlite_path) = sqlite_path {
+                if std::fs::metadata(sqlite_path).is_err() {
+                    if bootstrap {
+                        // bootstrap the database
+                        let rt = get_tokio_runtime();
+                        let from = BOOTSTRAP_URL.to_string();
+                        rt.block_on(async {
+                            if let Err(e) = download_file(&from, sqlite_path, silent).await {
+                                error!("failed to download bootstrap file: {}", e);
+                                exit(1);
+                            }
+                            // The update thread will handle the first update
+                        });
+                    } else {
+                        error!(
+                            "The specified database file does not exist. Consider run bootstrap command or serve command with `--bootstrap` flag."
+                        );
+                        exit(1);
+                    }
                 }
             }
 

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -50,10 +50,6 @@ enum Commands {
         /// or postgresql:// selects PostgreSQL; other values select a SQLite file.
         db_path: Option<String>,
 
-        /// Explicit PostgreSQL connection URL. Takes precedence over SQLite and can also be set with BGPKIT_BROKER_POSTGRES_URL.
-        #[clap(long)]
-        postgres_url: Option<String>,
-
         /// update interval in seconds
         #[clap(short = 'i', long, default_value = "300", value_parser = min_update_interval_check)]
         update_interval: u64,
@@ -448,14 +444,9 @@ fn display_configuration_summary(
     }
 }
 
-fn resolve_database_target(
-    database_path: Option<&str>,
-    postgres_url: Option<&str>,
-    config: &BrokerConfig,
-) -> DatabaseTarget {
+fn resolve_database_target(database_path: Option<&str>, config: &BrokerConfig) -> DatabaseTarget {
     DatabaseTarget::resolve(
         database_path,
-        postgres_url,
         config.database.postgres_url.as_deref(),
         config.database.sqlite_path.as_deref(),
     )
@@ -487,7 +478,6 @@ fn main() {
     match cli.command {
         Commands::Serve {
             db_path,
-            postgres_url,
             update_interval,
             bootstrap,
             silent,
@@ -505,8 +495,7 @@ fn main() {
 
             // Load configuration from environment variables
             let config = BrokerConfig::from_env();
-            let database_target =
-                resolve_database_target(db_path.as_deref(), postgres_url.as_deref(), &config);
+            let database_target = resolve_database_target(db_path.as_deref(), &config);
             let sqlite_path = match &database_target {
                 DatabaseTarget::Sqlite(path) => Some(path.as_str()),
                 DatabaseTarget::Postgres(_) => None,

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -438,8 +438,16 @@ fn display_configuration_summary(
     update_interval: u64,
     host: &str,
     port: u16,
+    database_target: &DatabaseTarget,
 ) {
-    for line in config.display_summary(do_update, do_api, update_interval, host, port) {
+    for line in config.display_summary(
+        do_update,
+        do_api,
+        update_interval,
+        host,
+        port,
+        database_target,
+    ) {
         info!("{}", line);
     }
 }
@@ -509,6 +517,7 @@ fn main() {
                     update_interval,
                     &host,
                     port,
+                    &database_target,
                 );
             }
 
@@ -570,7 +579,12 @@ fn main() {
                         }
                     };
                     rt.block_on(async {
-                        let mut db = match DatabaseBackend::connect(&database_target_clone).await {
+                        let mut db = match DatabaseBackend::connect(
+                            &database_target_clone,
+                            config_clone.database.postgres_max_connections,
+                        )
+                        .await
+                        {
                             Ok(db) => db,
                             Err(e) => {
                                 error!("failed to open database: {}", e);
@@ -707,7 +721,12 @@ fn main() {
                             exit(1);
                         }
                     }
-                    let database = match DatabaseBackend::connect(&database_target).await {
+                    let database = match DatabaseBackend::connect(
+                        &database_target,
+                        config.database.postgres_max_connections,
+                    )
+                    .await
+                    {
                         Ok(db) => db,
                         Err(e) => {
                             error!("failed to open database for API: {}", e);

--- a/src/config.rs
+++ b/src/config.rs
@@ -233,8 +233,9 @@ fn postgres_url_from_path(path: &str) -> Option<String> {
 }
 
 fn normalize_postgres_url(url: &str) -> String {
-    url.strip_prefix("pg://")
-        .map(|rest| format!("postgresql://{rest}"))
+    url.get(..5)
+        .filter(|prefix| prefix.eq_ignore_ascii_case("pg://"))
+        .map(|_| format!("postgresql://{}", &url[5..]))
         .unwrap_or_else(|| url.to_string())
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -166,18 +166,72 @@ impl HeartbeatConfig {
     }
 }
 
+/// Selected Broker database backend.
+///
+/// SQLite remains the default deployment contract. PostgreSQL is selected only
+/// when an explicit connection URL is supplied.
+#[derive(Clone, PartialEq, Eq)]
+pub enum DatabaseTarget {
+    Sqlite(String),
+    Postgres(String),
+}
+
+impl fmt::Debug for DatabaseTarget {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Sqlite(path) => formatter.debug_tuple("Sqlite").field(path).finish(),
+            Self::Postgres(_) => formatter
+                .debug_tuple("Postgres")
+                .field(&"<redacted>")
+                .finish(),
+        }
+    }
+}
+
+impl DatabaseTarget {
+    pub fn resolve(sqlite_path: Option<&str>, postgres_url: Option<&str>) -> Result<Self, String> {
+        if let Some(postgres_url) = postgres_url.filter(|url| !url.trim().is_empty()) {
+            return Ok(Self::Postgres(postgres_url.to_string()));
+        }
+        sqlite_path
+            .filter(|path| !path.trim().is_empty())
+            .map(|path| Self::Sqlite(path.to_string()))
+            .ok_or_else(|| {
+                "a SQLite database path is required unless PostgreSQL is explicitly configured"
+                    .to_string()
+            })
+    }
+}
+
 /// Database maintenance configuration.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct DatabaseConfig {
     /// Number of days to retain meta entries.
     /// Environment variable: `BGPKIT_BROKER_META_RETENTION_DAYS`
     pub meta_retention_days: i64,
+    /// Explicit PostgreSQL connection URL. When unset, callers use SQLite.
+    /// Environment variable: `BGPKIT_BROKER_POSTGRES_URL`
+    pub postgres_url: Option<String>,
+}
+
+impl fmt::Debug for DatabaseConfig {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter
+            .debug_struct("DatabaseConfig")
+            .field("meta_retention_days", &self.meta_retention_days)
+            .field(
+                "postgres_url",
+                &self.postgres_url.as_ref().map(|_| "<redacted>"),
+            )
+            .finish()
+    }
 }
 
 impl Default for DatabaseConfig {
     fn default() -> Self {
         Self {
             meta_retention_days: DEFAULT_META_RETENTION_DAYS,
+            postgres_url: None,
         }
     }
 }
@@ -190,6 +244,7 @@ impl DatabaseConfig {
                 .ok()
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(DEFAULT_META_RETENTION_DAYS),
+            postgres_url: std::env::var("BGPKIT_BROKER_POSTGRES_URL").ok(),
         }
     }
 }
@@ -345,5 +400,30 @@ mod tests {
             heartbeat_url: None,
         };
         assert_eq!(config.interval(), Duration::from_secs(12 * 60 * 60));
+    }
+
+    #[test]
+    fn database_target_prefers_explicit_postgres_url_without_changing_sqlite_default() {
+        assert_eq!(
+            DatabaseTarget::resolve(Some("broker.sqlite3"), None).unwrap(),
+            DatabaseTarget::Sqlite("broker.sqlite3".to_string())
+        );
+        assert_eq!(
+            DatabaseTarget::resolve(Some("broker.sqlite3"), Some("   ")).unwrap(),
+            DatabaseTarget::Sqlite("broker.sqlite3".to_string())
+        );
+        assert_eq!(
+            DatabaseTarget::resolve(
+                Some("broker.sqlite3"),
+                Some("postgresql://broker@localhost/bgpkit_platform"),
+            )
+            .unwrap(),
+            DatabaseTarget::Postgres("postgresql://broker@localhost/bgpkit_platform".to_string())
+        );
+    }
+
+    #[test]
+    fn database_target_requires_a_sqlite_path_without_postgres_opt_in() {
+        assert!(DatabaseTarget::resolve(None, None).is_err());
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -191,19 +191,15 @@ impl fmt::Debug for DatabaseTarget {
 pub const DEFAULT_SQLITE_PATH: &str = "bgpkit-broker.sqlite3";
 
 impl DatabaseTarget {
-    /// Resolve the database target with CLI values taking precedence over
-    /// environment configuration. A positional path beginning with `pg://`,
+    /// Resolve the database target with a positional CLI value taking precedence
+    /// over environment configuration. A positional path beginning with `pg://`,
     /// `postgres://`, or `postgresql://` selects PostgreSQL; any other path is
     /// a local SQLite file.
     pub fn resolve(
         database_path: Option<&str>,
-        cli_postgres_url: Option<&str>,
         environment_postgres_url: Option<&str>,
         environment_sqlite_path: Option<&str>,
     ) -> Self {
-        if let Some(url) = non_empty(cli_postgres_url) {
-            return Self::Postgres(normalize_postgres_url(url));
-        }
         if let Some(path) = non_empty(database_path) {
             return postgres_url_from_path(path)
                 .map(Self::Postgres)
@@ -447,17 +443,16 @@ mod tests {
     #[test]
     fn database_target_resolves_cli_path_and_environment_defaults() {
         assert_eq!(
-            DatabaseTarget::resolve(None, None, None, None),
+            DatabaseTarget::resolve(None, None, None),
             DatabaseTarget::Sqlite("bgpkit-broker.sqlite3".to_string())
         );
         assert_eq!(
-            DatabaseTarget::resolve(None, None, None, Some("/data/broker.sqlite3")),
+            DatabaseTarget::resolve(None, None, Some("/data/broker.sqlite3")),
             DatabaseTarget::Sqlite("/data/broker.sqlite3".to_string())
         );
         assert_eq!(
             DatabaseTarget::resolve(
                 Some("/tmp/override.sqlite3"),
-                None,
                 Some("postgresql://broker@db/catalog"),
                 Some("/data/broker.sqlite3"),
             ),
@@ -467,7 +462,6 @@ mod tests {
             DatabaseTarget::resolve(
                 Some("pg://broker@db/catalog"),
                 None,
-                None,
                 Some("/data/broker.sqlite3"),
             ),
             DatabaseTarget::Postgres("postgresql://broker@db/catalog".to_string())
@@ -476,22 +470,20 @@ mod tests {
             DatabaseTarget::resolve(
                 Some("postgresql://broker@db/catalog"),
                 None,
-                None,
                 Some("/data/broker.sqlite3"),
             ),
             DatabaseTarget::Postgres("postgresql://broker@db/catalog".to_string())
         );
         assert_eq!(
             DatabaseTarget::resolve(
-                Some("/tmp/override.sqlite3"),
-                Some("postgresql://broker@db/cli"),
+                None,
                 Some("postgresql://broker@db/environment"),
                 Some("/data/broker.sqlite3"),
             ),
-            DatabaseTarget::Postgres("postgresql://broker@db/cli".to_string())
+            DatabaseTarget::Postgres("postgresql://broker@db/environment".to_string())
         );
         assert_eq!(
-            DatabaseTarget::resolve(None, None, Some("   "), Some("   ")),
+            DatabaseTarget::resolve(None, Some("   "), Some("   ")),
             DatabaseTarget::Sqlite("bgpkit-broker.sqlite3".to_string())
         );
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -18,6 +18,7 @@ const DEFAULT_BACKUP_INTERVAL_HOURS: u64 = 24;
 
 /// Default values for database maintenance
 const DEFAULT_META_RETENTION_DAYS: i64 = 30;
+const DEFAULT_POSTGRES_MAX_CONNECTIONS: u32 = 10;
 
 /// Crawler configuration settings.
 ///
@@ -247,6 +248,9 @@ pub struct DatabaseConfig {
     /// SQLite catalog file path when no CLI database path or PostgreSQL URL is supplied.
     /// Environment variable: `BGPKIT_BROKER_SQLITE_PATH`
     pub sqlite_path: Option<String>,
+    /// Maximum number of connections in the PostgreSQL pool.
+    /// Environment variable: `BGPKIT_BROKER_POSTGRES_MAX_CONNECTIONS`
+    pub postgres_max_connections: u32,
 }
 
 impl fmt::Debug for DatabaseConfig {
@@ -259,6 +263,7 @@ impl fmt::Debug for DatabaseConfig {
                 &self.postgres_url.as_ref().map(|_| "<redacted>"),
             )
             .field("sqlite_path", &self.sqlite_path)
+            .field("postgres_max_connections", &self.postgres_max_connections)
             .finish()
     }
 }
@@ -269,6 +274,7 @@ impl Default for DatabaseConfig {
             meta_retention_days: DEFAULT_META_RETENTION_DAYS,
             postgres_url: None,
             sqlite_path: None,
+            postgres_max_connections: DEFAULT_POSTGRES_MAX_CONNECTIONS,
         }
     }
 }
@@ -283,6 +289,10 @@ impl DatabaseConfig {
                 .unwrap_or(DEFAULT_META_RETENTION_DAYS),
             postgres_url: std::env::var("BGPKIT_BROKER_POSTGRES_URL").ok(),
             sqlite_path: std::env::var("BGPKIT_BROKER_SQLITE_PATH").ok(),
+            postgres_max_connections: std::env::var("BGPKIT_BROKER_POSTGRES_MAX_CONNECTIONS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(DEFAULT_POSTGRES_MAX_CONNECTIONS),
         }
     }
 }
@@ -332,10 +342,14 @@ impl BrokerConfig {
         update_interval: u64,
         host: &str,
         port: u16,
+        database_target: &DatabaseTarget,
     ) -> Vec<String> {
         let mut lines = Vec::new();
 
         lines.push("=== BGPKIT Broker Configuration ===".to_string());
+
+        // Database backend (the Debug impl redacts PostgreSQL URLs)
+        lines.push(format!("Database backend: {:?}", database_target));
 
         // Update service status
         if do_update {

--- a/src/config.rs
+++ b/src/config.rs
@@ -188,19 +188,54 @@ impl fmt::Debug for DatabaseTarget {
     }
 }
 
+pub const DEFAULT_SQLITE_PATH: &str = "bgpkit-broker.sqlite3";
+
 impl DatabaseTarget {
-    pub fn resolve(sqlite_path: Option<&str>, postgres_url: Option<&str>) -> Result<Self, String> {
-        if let Some(postgres_url) = postgres_url.filter(|url| !url.trim().is_empty()) {
-            return Ok(Self::Postgres(postgres_url.to_string()));
+    /// Resolve the database target with CLI values taking precedence over
+    /// environment configuration. A positional path beginning with `pg://`,
+    /// `postgres://`, or `postgresql://` selects PostgreSQL; any other path is
+    /// a local SQLite file.
+    pub fn resolve(
+        database_path: Option<&str>,
+        cli_postgres_url: Option<&str>,
+        environment_postgres_url: Option<&str>,
+        environment_sqlite_path: Option<&str>,
+    ) -> Self {
+        if let Some(url) = non_empty(cli_postgres_url) {
+            return Self::Postgres(normalize_postgres_url(url));
         }
-        sqlite_path
-            .filter(|path| !path.trim().is_empty())
-            .map(|path| Self::Sqlite(path.to_string()))
-            .ok_or_else(|| {
-                "a SQLite database path is required unless PostgreSQL is explicitly configured"
-                    .to_string()
-            })
+        if let Some(path) = non_empty(database_path) {
+            return postgres_url_from_path(path)
+                .map(Self::Postgres)
+                .unwrap_or_else(|| Self::Sqlite(path.to_string()));
+        }
+        if let Some(url) = non_empty(environment_postgres_url) {
+            return Self::Postgres(normalize_postgres_url(url));
+        }
+        Self::Sqlite(
+            non_empty(environment_sqlite_path)
+                .unwrap_or(DEFAULT_SQLITE_PATH)
+                .to_string(),
+        )
     }
+}
+
+fn non_empty(value: Option<&str>) -> Option<&str> {
+    value.map(str::trim).filter(|value| !value.is_empty())
+}
+
+fn postgres_url_from_path(path: &str) -> Option<String> {
+    let lowercase_path = path.to_ascii_lowercase();
+    (lowercase_path.starts_with("pg://")
+        || lowercase_path.starts_with("postgres://")
+        || lowercase_path.starts_with("postgresql://"))
+    .then(|| normalize_postgres_url(path))
+}
+
+fn normalize_postgres_url(url: &str) -> String {
+    url.strip_prefix("pg://")
+        .map(|rest| format!("postgresql://{rest}"))
+        .unwrap_or_else(|| url.to_string())
 }
 
 /// Database maintenance configuration.
@@ -212,6 +247,9 @@ pub struct DatabaseConfig {
     /// Explicit PostgreSQL connection URL. When unset, callers use SQLite.
     /// Environment variable: `BGPKIT_BROKER_POSTGRES_URL`
     pub postgres_url: Option<String>,
+    /// SQLite catalog file path when no CLI database path or PostgreSQL URL is supplied.
+    /// Environment variable: `BGPKIT_BROKER_SQLITE_PATH`
+    pub sqlite_path: Option<String>,
 }
 
 impl fmt::Debug for DatabaseConfig {
@@ -223,6 +261,7 @@ impl fmt::Debug for DatabaseConfig {
                 "postgres_url",
                 &self.postgres_url.as_ref().map(|_| "<redacted>"),
             )
+            .field("sqlite_path", &self.sqlite_path)
             .finish()
     }
 }
@@ -232,6 +271,7 @@ impl Default for DatabaseConfig {
         Self {
             meta_retention_days: DEFAULT_META_RETENTION_DAYS,
             postgres_url: None,
+            sqlite_path: None,
         }
     }
 }
@@ -245,6 +285,7 @@ impl DatabaseConfig {
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(DEFAULT_META_RETENTION_DAYS),
             postgres_url: std::env::var("BGPKIT_BROKER_POSTGRES_URL").ok(),
+            sqlite_path: std::env::var("BGPKIT_BROKER_SQLITE_PATH").ok(),
         }
     }
 }
@@ -403,27 +444,54 @@ mod tests {
     }
 
     #[test]
-    fn database_target_prefers_explicit_postgres_url_without_changing_sqlite_default() {
+    fn database_target_resolves_cli_path_and_environment_defaults() {
         assert_eq!(
-            DatabaseTarget::resolve(Some("broker.sqlite3"), None).unwrap(),
-            DatabaseTarget::Sqlite("broker.sqlite3".to_string())
+            DatabaseTarget::resolve(None, None, None, None),
+            DatabaseTarget::Sqlite("bgpkit-broker.sqlite3".to_string())
         );
         assert_eq!(
-            DatabaseTarget::resolve(Some("broker.sqlite3"), Some("   ")).unwrap(),
-            DatabaseTarget::Sqlite("broker.sqlite3".to_string())
+            DatabaseTarget::resolve(None, None, None, Some("/data/broker.sqlite3")),
+            DatabaseTarget::Sqlite("/data/broker.sqlite3".to_string())
         );
         assert_eq!(
             DatabaseTarget::resolve(
-                Some("broker.sqlite3"),
-                Some("postgresql://broker@localhost/bgpkit_platform"),
-            )
-            .unwrap(),
-            DatabaseTarget::Postgres("postgresql://broker@localhost/bgpkit_platform".to_string())
+                Some("/tmp/override.sqlite3"),
+                None,
+                Some("postgresql://broker@db/catalog"),
+                Some("/data/broker.sqlite3"),
+            ),
+            DatabaseTarget::Sqlite("/tmp/override.sqlite3".to_string())
         );
-    }
-
-    #[test]
-    fn database_target_requires_a_sqlite_path_without_postgres_opt_in() {
-        assert!(DatabaseTarget::resolve(None, None).is_err());
+        assert_eq!(
+            DatabaseTarget::resolve(
+                Some("pg://broker@db/catalog"),
+                None,
+                None,
+                Some("/data/broker.sqlite3"),
+            ),
+            DatabaseTarget::Postgres("postgresql://broker@db/catalog".to_string())
+        );
+        assert_eq!(
+            DatabaseTarget::resolve(
+                Some("postgresql://broker@db/catalog"),
+                None,
+                None,
+                Some("/data/broker.sqlite3"),
+            ),
+            DatabaseTarget::Postgres("postgresql://broker@db/catalog".to_string())
+        );
+        assert_eq!(
+            DatabaseTarget::resolve(
+                Some("/tmp/override.sqlite3"),
+                Some("postgresql://broker@db/cli"),
+                Some("postgresql://broker@db/environment"),
+                Some("/data/broker.sqlite3"),
+            ),
+            DatabaseTarget::Postgres("postgresql://broker@db/cli".to_string())
+        );
+        assert_eq!(
+            DatabaseTarget::resolve(None, None, Some("   "), Some("   ")),
+            DatabaseTarget::Sqlite("bgpkit-broker.sqlite3".to_string())
+        );
     }
 }

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -1,0 +1,136 @@
+use super::{DbSearchResult, LocalBrokerDb, PostgresDb, UpdatesMeta};
+use crate::config::DatabaseTarget;
+use crate::{BrokerError, BrokerItem, Collector};
+use chrono::NaiveDateTime;
+
+#[derive(Clone)]
+pub enum DatabaseBackend {
+    Sqlite(LocalBrokerDb),
+    Postgres(PostgresDb),
+}
+
+impl DatabaseBackend {
+    pub async fn connect(target: &DatabaseTarget) -> Result<Self, BrokerError> {
+        match target {
+            DatabaseTarget::Sqlite(path) => LocalBrokerDb::new(path).await.map(Self::Sqlite),
+            DatabaseTarget::Postgres(url) => PostgresDb::new(url).await.map(Self::Postgres),
+        }
+    }
+
+    pub async fn reload_collectors(&mut self) -> Result<(), BrokerError> {
+        match self {
+            Self::Sqlite(database) => {
+                database.reload_collectors().await;
+                Ok(())
+            }
+            Self::Postgres(database) => database.reload_collectors().await,
+        }
+    }
+
+    pub async fn analyze(&self) -> Result<(), BrokerError> {
+        match self {
+            Self::Sqlite(database) => database.analyze().await,
+            Self::Postgres(database) => database.analyze().await,
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn search(
+        &self,
+        collectors: Option<Vec<String>>,
+        project: Option<String>,
+        data_type: Option<String>,
+        ts_start: Option<NaiveDateTime>,
+        ts_end: Option<NaiveDateTime>,
+        page: Option<usize>,
+        page_size: Option<usize>,
+    ) -> Result<DbSearchResult, BrokerError> {
+        match self {
+            Self::Sqlite(database) => {
+                database
+                    .search(
+                        collectors, project, data_type, ts_start, ts_end, page, page_size,
+                    )
+                    .await
+            }
+            Self::Postgres(database) => {
+                database
+                    .search(
+                        collectors, project, data_type, ts_start, ts_end, page, page_size,
+                    )
+                    .await
+            }
+        }
+    }
+
+    pub async fn insert_items(
+        &self,
+        items: &[BrokerItem],
+        update_latest: bool,
+    ) -> Result<Vec<BrokerItem>, BrokerError> {
+        match self {
+            Self::Sqlite(database) => database.insert_items(items, update_latest).await,
+            Self::Postgres(database) => database.insert_items(items, update_latest).await,
+        }
+    }
+
+    pub async fn insert_collector(&self, collector: &Collector) -> Result<(), BrokerError> {
+        match self {
+            Self::Sqlite(database) => database.insert_collector(collector).await,
+            Self::Postgres(database) => database.insert_collector(collector).await,
+        }
+    }
+
+    pub async fn get_latest_timestamp(&self) -> Result<Option<NaiveDateTime>, BrokerError> {
+        match self {
+            Self::Sqlite(database) => database.get_latest_timestamp().await,
+            Self::Postgres(database) => database.get_latest_timestamp().await,
+        }
+    }
+
+    pub async fn get_latest_files(&self) -> Vec<BrokerItem> {
+        match self {
+            Self::Sqlite(database) => database.get_latest_files().await,
+            Self::Postgres(database) => database.get_latest_files().await,
+        }
+    }
+
+    pub async fn update_latest_files(
+        &self,
+        files: &[BrokerItem],
+        bootstrap: bool,
+    ) -> Result<(), BrokerError> {
+        match self {
+            Self::Sqlite(database) => {
+                database.update_latest_files(files, bootstrap).await;
+                Ok(())
+            }
+            Self::Postgres(database) => database.update_latest_files(files, bootstrap).await,
+        }
+    }
+
+    pub async fn insert_meta(
+        &self,
+        crawl_duration: i32,
+        item_inserted: i32,
+    ) -> Result<Vec<UpdatesMeta>, BrokerError> {
+        match self {
+            Self::Sqlite(database) => database.insert_meta(crawl_duration, item_inserted).await,
+            Self::Postgres(database) => database.insert_meta(crawl_duration, item_inserted).await,
+        }
+    }
+
+    pub async fn get_latest_updates_meta(&self) -> Result<Option<UpdatesMeta>, BrokerError> {
+        match self {
+            Self::Sqlite(database) => database.get_latest_updates_meta().await,
+            Self::Postgres(database) => database.get_latest_updates_meta().await,
+        }
+    }
+
+    pub async fn cleanup_old_meta_entries(&self, retention_days: i64) -> Result<(), BrokerError> {
+        match self {
+            Self::Sqlite(database) => database.cleanup_old_meta_entries().await.map(|_| ()),
+            Self::Postgres(database) => database.cleanup_old_meta_entries(retention_days).await,
+        }
+    }
+}

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -10,10 +10,15 @@ pub enum DatabaseBackend {
 }
 
 impl DatabaseBackend {
-    pub async fn connect(target: &DatabaseTarget) -> Result<Self, BrokerError> {
+    pub async fn connect(
+        target: &DatabaseTarget,
+        max_connections: u32,
+    ) -> Result<Self, BrokerError> {
         match target {
             DatabaseTarget::Sqlite(path) => LocalBrokerDb::new(path).await.map(Self::Sqlite),
-            DatabaseTarget::Postgres(url) => PostgresDb::new(url).await.map(Self::Postgres),
+            DatabaseTarget::Postgres(url) => PostgresDb::new(url, max_connections)
+                .await
+                .map(Self::Postgres),
         }
     }
 

--- a/src/db/meta.rs
+++ b/src/db/meta.rs
@@ -114,9 +114,12 @@ impl LocalBrokerDb {
             retention_days, cutoff_ts
         );
 
-        let result = sqlx::query(sqlx::AssertSqlSafe(format!("DELETE FROM meta WHERE update_ts < {}", cutoff_ts)))
-            .execute(&self.conn_pool)
-            .await?;
+        let result = sqlx::query(sqlx::AssertSqlSafe(format!(
+            "DELETE FROM meta WHERE update_ts < {}",
+            cutoff_ts
+        )))
+        .execute(&self.conn_pool)
+        .await?;
 
         let deleted = result.rows_affected();
         if deleted > 0 {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -1,6 +1,13 @@
+#[cfg(feature = "cli")]
+mod backend;
 mod latest_files;
 mod meta;
+mod postgres;
 mod utils;
+
+#[cfg(feature = "cli")]
+pub use backend::DatabaseBackend;
+pub use postgres::PostgresDb;
 
 use crate::db::utils::infer_url;
 use crate::query::{BrokerCollector, BrokerItemType};
@@ -308,34 +315,36 @@ impl LocalBrokerDb {
             .map(|c| (c.name.clone(), c.clone()))
             .collect::<HashMap<String, BrokerCollector>>();
 
-        let items: Vec<Option<BrokerItem>> = sqlx::query(sqlx::AssertSqlSafe(query_string.as_str()))
-            .map(|row: SqliteRow| {
-                let collector_name = row.get::<String, _>("collector_name");
-                let _collector_url = row.get::<String, _>("collector_url");
-                let _project_name = row.get::<String, _>("project_name");
-                let timestamp = row.get::<i64, _>("timestamp");
-                let type_name = row.get::<String, _>("type");
-                let rough_size = row.get::<i64, _>("rough_size");
-                let exact_size = row.get::<i64, _>("exact_size");
-                let _updates_interval = row.get::<i64, _>("updates_interval");
+        let items: Vec<Option<BrokerItem>> =
+            sqlx::query(sqlx::AssertSqlSafe(query_string.as_str()))
+                .map(|row: SqliteRow| {
+                    let collector_name = row.get::<String, _>("collector_name");
+                    let _collector_url = row.get::<String, _>("collector_url");
+                    let _project_name = row.get::<String, _>("project_name");
+                    let timestamp = row.get::<i64, _>("timestamp");
+                    let type_name = row.get::<String, _>("type");
+                    let rough_size = row.get::<i64, _>("rough_size");
+                    let exact_size = row.get::<i64, _>("exact_size");
+                    let _updates_interval = row.get::<i64, _>("updates_interval");
 
-                let collector = collector_name_to_info.get(collector_name.as_str())?;
+                    let collector = collector_name_to_info.get(collector_name.as_str())?;
 
-                let ts_start = DateTime::from_timestamp(timestamp, 0)?.naive_utc();
+                    let ts_start = DateTime::from_timestamp(timestamp, 0)?.naive_utc();
 
-                let (url, ts_end) = infer_url(collector, &ts_start, type_name.as_str() == "rib");
-                Some(BrokerItem {
-                    ts_start,
-                    ts_end,
-                    collector_id: collector_name,
-                    data_type: type_name,
-                    url,
-                    rough_size,
-                    exact_size,
+                    let (url, ts_end) =
+                        infer_url(collector, &ts_start, type_name.as_str() == "rib");
+                    Some(BrokerItem {
+                        ts_start,
+                        ts_end,
+                        collector_id: collector_name,
+                        data_type: type_name,
+                        url,
+                        rough_size,
+                        exact_size,
+                    })
                 })
-            })
-            .fetch_all(&self.conn_pool)
-            .await?;
+                .fetch_all(&self.conn_pool)
+                .await?;
 
         Ok(DbSearchResult {
             items: items.into_iter().flatten().collect(),

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -24,6 +24,13 @@ pub use meta::UpdatesMeta;
 
 pub const DEFAULT_PAGE_SIZE: usize = 100;
 
+/// Update-file lookback window for RIPE RIS collectors, in seconds.
+/// RIPE RIS publishes update files every 5 minutes.
+pub const UPDATES_LOOKBACK_RIPE_RIS_SECS: i64 = 5 * 60;
+/// Update-file lookback window for RouteViews collectors, in seconds.
+/// RouteViews publishes update files every 15 minutes.
+pub const UPDATES_LOOKBACK_ROUTE_VIEWS_SECS: i64 = 15 * 60;
+
 #[derive(Clone)]
 pub struct LocalBrokerDb {
     /// shared connection pool for reading and writing
@@ -48,11 +55,7 @@ fn get_ts_start_clause(ts: i64) -> String {
                 OR (type='rib' AND timestamp >= {})
             )
                 "#,
-        ts,
-        5 * 60,
-        ts,
-        15 * 60,
-        ts
+        ts, UPDATES_LOOKBACK_RIPE_RIS_SECS, ts, UPDATES_LOOKBACK_ROUTE_VIEWS_SECS, ts
     )
 }
 
@@ -252,11 +255,11 @@ impl LocalBrokerDb {
             }
             (Some(ts_start), Some(ts_end)) => {
                 let start = ts_start;
+                // When searching with the same start and end timestamp, always
+                // include the given timestamp by expanding the end by 1 second.
+                // The PostgreSQL backend mirrors this in `normalize_search_end`.
                 let end = match ts_start == ts_end {
-                    true => {
-                        // making sure when searching with the same timestamp, we always include the given timestamp
-                        ts_start + Duration::seconds(1)
-                    }
+                    true => ts_start + Duration::seconds(1),
                     false => ts_end,
                 };
                 where_clauses.push(get_ts_start_clause(start.and_utc().timestamp()));

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -8,12 +8,12 @@ use sqlx::{PgPool, Postgres, QueryBuilder, Row};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
 
-/// Read-only PostgreSQL adapter for a catalog bootstrapped with
-/// `migration/postgres_bootstrap`.
+/// PostgreSQL adapter for a Broker catalog initialized with
+/// `migration/postgres_bootstrap/bootstrap.py`.
 ///
-/// It uses fully-qualified relations from the PostgreSQL compatibility schema.
-/// Live ingestion intentionally remains unavailable until the crawler can create
-/// accurate source-revision and ingest-run provenance for every observation batch.
+/// It uses fully-qualified relations from the PostgreSQL compatibility schema and
+/// supports the same catalog writes, latest-file maintenance, and update metadata
+/// lifecycle as the SQLite backend.
 #[derive(Clone)]
 pub struct PostgresDb {
     conn_pool: PgPool,
@@ -510,19 +510,23 @@ mod tests {
     use super::*;
 
     #[tokio::test]
-    #[ignore = "requires BGPKIT_BROKER_TEST_POSTGRES_URL and a bootstrap schema"]
+    #[ignore = "requires BGPKIT_BROKER_TEST_POSTGRES_URL pointing to a disposable bootstrapped database"]
     async fn postgres_catalog_writes_update_latest_and_meta(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let database_url = std::env::var("BGPKIT_BROKER_TEST_POSTGRES_URL")?;
         let database = PostgresDb::new(&database_url).await?;
-        database.cleanup_old_meta_entries(0).await?;
-        let timestamp = DateTime::from_timestamp(1_704_067_500, 0)
-            .ok_or_else(|| std::io::Error::other("test timestamp is invalid"))?
-            .naive_utc();
+        let collector = Collector {
+            id: "pg-runtime-test".to_string(),
+            project: "riperis".to_string(),
+            url: "https://example.invalid/pg-runtime-test".to_string(),
+        };
+        database.insert_collector(&collector).await?;
+        database.reload_collectors().await?;
+        let timestamp = Utc::now().naive_utc();
         let item = BrokerItem {
             ts_start: timestamp,
             ts_end: timestamp + Duration::seconds(300),
-            collector_id: "rrc00".to_string(),
+            collector_id: collector.id.clone(),
             data_type: "updates".to_string(),
             url: "https://example.invalid/updates.20240101.0000.gz".to_string(),
             rough_size: 56,
@@ -531,8 +535,11 @@ mod tests {
 
         let inserted = database.insert_items(&[item], true).await?;
         assert_eq!(inserted.len(), 1);
-        assert_eq!(database.get_latest_files().await.len(), 1);
-        assert!(database.get_latest_updates_meta().await?.is_none());
+        assert!(database
+            .get_latest_files()
+            .await
+            .iter()
+            .any(|latest| latest.collector_id == collector.id));
         assert_eq!(database.insert_meta(3, 1).await?.len(), 1);
         assert_eq!(
             database
@@ -541,8 +548,6 @@ mod tests {
                 .map(|meta| meta.insert_count),
             Some(1)
         );
-        database.cleanup_old_meta_entries(0).await?;
-        assert!(database.get_latest_updates_meta().await?.is_none());
         Ok(())
     }
 

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1,0 +1,559 @@
+use super::{DbSearchResult, UpdatesMeta, DEFAULT_PAGE_SIZE};
+use crate::db::utils::infer_url;
+use crate::query::BrokerCollector;
+use crate::{BrokerError, BrokerItem, Collector};
+use chrono::{DateTime, Duration, NaiveDateTime, Utc};
+use sqlx::postgres::{PgPoolOptions, PgRow};
+use sqlx::{PgPool, Postgres, QueryBuilder, Row};
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+/// Read-only PostgreSQL adapter for a catalog bootstrapped with
+/// `migration/postgres_bootstrap`.
+///
+/// It uses fully-qualified relations from the PostgreSQL compatibility schema.
+/// Live ingestion intentionally remains unavailable until the crawler can create
+/// accurate source-revision and ingest-run provenance for every observation batch.
+#[derive(Clone)]
+pub struct PostgresDb {
+    conn_pool: PgPool,
+    collectors: Arc<RwLock<Vec<BrokerCollector>>>,
+}
+
+impl PostgresDb {
+    pub async fn new(database_url: &str) -> Result<Self, BrokerError> {
+        let conn_pool = PgPoolOptions::new()
+            .max_connections(10)
+            .connect(database_url)
+            .await
+            .map_err(database_error)?;
+        let db = Self {
+            conn_pool,
+            collectors: Arc::new(RwLock::new(Vec::new())),
+        };
+        db.reload_collectors().await?;
+        Ok(db)
+    }
+
+    pub async fn reload_collectors(&self) -> Result<(), BrokerError> {
+        let collectors = sqlx::query(
+            "SELECT c.collector_id, c.name, c.base_uri, p.name AS project, c.updates_interval_seconds \
+             FROM mrt.collector AS c \
+             JOIN mrt.project AS p USING (project_id) \
+             ORDER BY c.collector_id",
+        )
+        .map(|row: PgRow| BrokerCollector {
+            id: row.get("collector_id"),
+            name: row.get("name"),
+            url: row.get("base_uri"),
+            project: row.get("project"),
+            updates_interval: i64::from(
+                row.try_get::<i32, _>("updates_interval_seconds")
+                    .unwrap_or_default(),
+            ),
+        })
+        .fetch_all(&self.conn_pool)
+        .await
+        .map_err(database_error)?;
+        let mut cached = self.collectors.write().map_err(|_| {
+            BrokerError::BrokerError("PostgreSQL collector cache lock poisoned".to_string())
+        })?;
+        *cached = collectors;
+        Ok(())
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub async fn search(
+        &self,
+        collectors: Option<Vec<String>>,
+        project: Option<String>,
+        data_type: Option<String>,
+        ts_start: Option<NaiveDateTime>,
+        ts_end: Option<NaiveDateTime>,
+        page: Option<usize>,
+        page_size: Option<usize>,
+    ) -> Result<DbSearchResult, BrokerError> {
+        validate_project(project.as_deref())?;
+        let data_type = normalize_data_type(data_type.as_deref())?;
+        let ts_end = normalize_search_end(ts_start, ts_end);
+        let page = page.unwrap_or(1);
+        if page == 0 {
+            return Err(BrokerError::BrokerError("page must start at 1".to_string()));
+        }
+        let page_size = page_size.unwrap_or(DEFAULT_PAGE_SIZE);
+        let total = self
+            .search_count(&collectors, project.as_deref(), data_type, ts_start, ts_end)
+            .await?;
+
+        let mut query = QueryBuilder::<Postgres>::new(
+            "SELECT collector_name, timestamp, type, rough_size, exact_size \
+             FROM api.mrt_file_search",
+        );
+        apply_search_filters(
+            &mut query,
+            &collectors,
+            project.as_deref(),
+            data_type,
+            ts_start,
+            ts_end,
+        );
+        query.push(" ORDER BY timestamp ASC, type ASC, collector_name ASC");
+        query.push(" LIMIT ").push_bind(page_size as i64);
+        query
+            .push(" OFFSET ")
+            .push_bind(((page - 1) * page_size) as i64);
+
+        let rows = query
+            .build()
+            .fetch_all(&self.conn_pool)
+            .await
+            .map_err(database_error)?;
+        let collector_map = self.collector_map()?;
+        let items = rows
+            .into_iter()
+            .filter_map(|row| pg_row_to_item(row, &collector_map))
+            .collect();
+        Ok(DbSearchResult {
+            items,
+            page,
+            page_size,
+            total,
+        })
+    }
+
+    pub async fn get_latest_timestamp(&self) -> Result<Option<NaiveDateTime>, BrokerError> {
+        let timestamp: Option<DateTime<Utc>> =
+            sqlx::query_scalar("SELECT max(ts_start) FROM mrt.file")
+                .fetch_one(&self.conn_pool)
+                .await
+                .map_err(database_error)?;
+        Ok(timestamp.map(|timestamp| timestamp.naive_utc()))
+    }
+
+    pub async fn get_latest_files(&self) -> Vec<BrokerItem> {
+        let rows = match sqlx::query(
+            "SELECT collector_name, timestamp, type, rough_size, exact_size \
+             FROM api.mrt_file_latest",
+        )
+        .fetch_all(&self.conn_pool)
+        .await
+        {
+            Ok(rows) => rows,
+            Err(_) => return Vec::new(),
+        };
+        let collector_map = match self.collector_map() {
+            Ok(collectors) => collectors,
+            Err(_) => return Vec::new(),
+        };
+        rows.into_iter()
+            .filter_map(|row| pg_row_to_item(row, &collector_map))
+            .collect()
+    }
+
+    pub async fn get_latest_updates_meta(&self) -> Result<Option<UpdatesMeta>, BrokerError> {
+        let row = sqlx::query(
+            "SELECT extract(epoch FROM update_ts)::bigint AS update_ts, \
+                update_duration_seconds AS update_duration, insert_count \
+             FROM mrt.update_meta ORDER BY update_ts DESC LIMIT 1",
+        )
+        .fetch_optional(&self.conn_pool)
+        .await
+        .map_err(database_error)?;
+        Ok(row.map(|row| UpdatesMeta {
+            update_ts: row.get("update_ts"),
+            update_duration: row.get("update_duration"),
+            insert_count: row.get("insert_count"),
+        }))
+    }
+
+    pub async fn analyze(&self) -> Result<(), BrokerError> {
+        for statement in [
+            "ANALYZE mrt.file",
+            "ANALYZE mrt.collector",
+            "ANALYZE mrt.latest_file",
+        ] {
+            sqlx::query(statement)
+                .execute(&self.conn_pool)
+                .await
+                .map_err(database_error)?;
+        }
+        Ok(())
+    }
+
+    pub async fn insert_items(
+        &self,
+        items: &[BrokerItem],
+        update_latest: bool,
+    ) -> Result<Vec<BrokerItem>, BrokerError> {
+        if items.is_empty() {
+            return Ok(Vec::new());
+        }
+        let collector_map = self.collector_map()?;
+        let mut inserted = Vec::new();
+        for batch in items.chunks(1000) {
+            let mut query = QueryBuilder::<Postgres>::new(
+                "INSERT INTO mrt.file (ts_start, collector_id, data_type, rough_size, exact_size) ",
+            );
+            query.push_values(batch, |mut values, item| {
+                values
+                    .push_bind(item.ts_start.and_utc())
+                    .push_bind(
+                        collector_map
+                            .get(item.collector_id.as_str())
+                            .map(|collector| collector.id),
+                    )
+                    .push_bind(item.data_type.as_str())
+                    .push_bind(item.rough_size)
+                    .push_bind(item.exact_size);
+            });
+            query.push(
+                " ON CONFLICT (ts_start, collector_id, data_type) DO NOTHING \
+                 RETURNING ts_start, collector_id, data_type, rough_size, exact_size",
+            );
+            let rows = query
+                .build()
+                .fetch_all(&self.conn_pool)
+                .await
+                .map_err(database_error)?;
+            for row in rows {
+                let collector_id: i64 = row.get("collector_id");
+                if let Some(collector) = collector_map
+                    .values()
+                    .find(|collector| collector.id == collector_id)
+                {
+                    inserted.push(row_to_item(row, collector));
+                }
+            }
+        }
+        if update_latest {
+            self.update_latest_files(&inserted, false).await?;
+        }
+        Ok(inserted)
+    }
+
+    pub async fn insert_collector(&self, collector: &Collector) -> Result<(), BrokerError> {
+        let project = normalize_project(&collector.project)?;
+        let interval = if project == "ripe-ris" { 300 } else { 900 };
+        sqlx::query(
+            "INSERT INTO mrt.collector (project_id, name, base_uri, updates_interval_seconds) \
+             SELECT project_id, $1, $2, $3 FROM mrt.project WHERE name = $4 \
+             ON CONFLICT (project_id, name) DO UPDATE SET \
+                 base_uri = EXCLUDED.base_uri, updates_interval_seconds = EXCLUDED.updates_interval_seconds",
+        )
+        .bind(&collector.id)
+        .bind(&collector.url)
+        .bind(interval)
+        .bind(project)
+        .execute(&self.conn_pool)
+        .await
+        .map_err(database_error)?;
+        Ok(())
+    }
+
+    pub async fn update_latest_files(
+        &self,
+        files: &[BrokerItem],
+        bootstrap: bool,
+    ) -> Result<(), BrokerError> {
+        if bootstrap {
+            sqlx::query("TRUNCATE mrt.latest_file")
+                .execute(&self.conn_pool)
+                .await
+                .map_err(database_error)?;
+            sqlx::query(
+                "INSERT INTO mrt.latest_file (collector_id, data_type, ts_start, rough_size, exact_size) \
+                 SELECT DISTINCT ON (collector_id, data_type) \
+                    collector_id, data_type, ts_start, rough_size, exact_size \
+                 FROM mrt.file ORDER BY collector_id, data_type, ts_start DESC",
+            )
+            .execute(&self.conn_pool)
+            .await
+            .map_err(database_error)?;
+            return Ok(());
+        }
+        if files.is_empty() {
+            return Ok(());
+        }
+        let collector_map = self.collector_map()?;
+        for batch in files.chunks(1000) {
+            let mut query = QueryBuilder::<Postgres>::new(
+                "INSERT INTO mrt.latest_file (collector_id, data_type, ts_start, rough_size, exact_size) ",
+            );
+            query.push_values(batch, |mut values, item| {
+                values
+                    .push_bind(
+                        collector_map
+                            .get(item.collector_id.as_str())
+                            .map(|collector| collector.id),
+                    )
+                    .push_bind(item.data_type.as_str())
+                    .push_bind(item.ts_start.and_utc())
+                    .push_bind(item.rough_size)
+                    .push_bind(item.exact_size);
+            });
+            query.push(
+                " ON CONFLICT (collector_id, data_type) DO UPDATE SET \
+                    ts_start = EXCLUDED.ts_start, rough_size = EXCLUDED.rough_size, \
+                    exact_size = EXCLUDED.exact_size \
+                  WHERE EXCLUDED.ts_start > mrt.latest_file.ts_start",
+            );
+            query
+                .build()
+                .execute(&self.conn_pool)
+                .await
+                .map_err(database_error)?;
+        }
+        Ok(())
+    }
+
+    pub async fn insert_meta(
+        &self,
+        crawl_duration: i32,
+        item_inserted: i32,
+    ) -> Result<Vec<UpdatesMeta>, BrokerError> {
+        let row = sqlx::query(
+            "INSERT INTO mrt.update_meta (update_ts, update_duration_seconds, insert_count) \
+             VALUES (now(), $1, $2) \
+             RETURNING extract(epoch FROM update_ts)::bigint AS update_ts, \
+                       update_duration_seconds AS update_duration, insert_count",
+        )
+        .bind(crawl_duration)
+        .bind(item_inserted)
+        .fetch_one(&self.conn_pool)
+        .await
+        .map_err(database_error)?;
+        Ok(vec![UpdatesMeta {
+            update_ts: row.get("update_ts"),
+            update_duration: row.get("update_duration"),
+            insert_count: row.get("insert_count"),
+        }])
+    }
+
+    pub async fn cleanup_old_meta_entries(&self, retention_days: i64) -> Result<(), BrokerError> {
+        sqlx::query(
+            "DELETE FROM mrt.update_meta WHERE update_ts < now() - ($1::bigint * interval '1 day')",
+        )
+        .bind(retention_days)
+        .execute(&self.conn_pool)
+        .await
+        .map_err(database_error)?;
+        Ok(())
+    }
+
+    fn collector_map(&self) -> Result<HashMap<String, BrokerCollector>, BrokerError> {
+        self.collectors
+            .read()
+            .map_err(|_| {
+                BrokerError::BrokerError("PostgreSQL collector cache lock poisoned".to_string())
+            })
+            .map(|collectors| {
+                collectors
+                    .iter()
+                    .map(|collector| (collector.name.clone(), collector.clone()))
+                    .collect()
+            })
+    }
+
+    async fn search_count(
+        &self,
+        collectors: &Option<Vec<String>>,
+        project: Option<&str>,
+        data_type: Option<&str>,
+        ts_start: Option<NaiveDateTime>,
+        ts_end: Option<NaiveDateTime>,
+    ) -> Result<usize, BrokerError> {
+        let mut query = QueryBuilder::<Postgres>::new("SELECT count(*) FROM api.mrt_file_search");
+        apply_search_filters(&mut query, collectors, project, data_type, ts_start, ts_end);
+        let total: i64 = query
+            .build_query_scalar()
+            .fetch_one(&self.conn_pool)
+            .await
+            .map_err(database_error)?;
+        usize::try_from(total)
+            .map_err(|_| BrokerError::BrokerError("database count exceeds usize".to_string()))
+    }
+}
+
+fn database_error(error: sqlx::Error) -> BrokerError {
+    BrokerError::BrokerError(format!("PostgreSQL error: {error}"))
+}
+
+fn normalize_project(project: &str) -> Result<&str, BrokerError> {
+    match project.to_lowercase().as_str() {
+        "ris" | "riperis" | "ripe-ris" => Ok("ripe-ris"),
+        "routeviews" | "rv" | "route-views" => Ok("route-views"),
+        _ => Err(BrokerError::BrokerError(format!(
+            "Unknown project: {project}"
+        ))),
+    }
+}
+
+fn validate_project(project: Option<&str>) -> Result<(), BrokerError> {
+    if let Some(project) = project {
+        normalize_project(project)?;
+    }
+    Ok(())
+}
+
+fn normalize_data_type(data_type: Option<&str>) -> Result<Option<&str>, BrokerError> {
+    match data_type {
+        None => Ok(None),
+        Some("updates" | "update" | "u") => Ok(Some("updates")),
+        Some("rib" | "ribs" | "r") => Ok(Some("rib")),
+        Some(other) => Err(BrokerError::BrokerError(format!(
+            "Unknown data_type: {other}"
+        ))),
+    }
+}
+
+fn normalize_search_end(
+    ts_start: Option<NaiveDateTime>,
+    ts_end: Option<NaiveDateTime>,
+) -> Option<NaiveDateTime> {
+    match (ts_start, ts_end) {
+        (Some(start), Some(end)) if start == end => Some(end + Duration::seconds(1)),
+        (_, end) => end,
+    }
+}
+
+fn apply_search_filters(
+    query: &mut QueryBuilder<Postgres>,
+    collectors: &Option<Vec<String>>,
+    project: Option<&str>,
+    data_type: Option<&str>,
+    ts_start: Option<NaiveDateTime>,
+    ts_end: Option<NaiveDateTime>,
+) {
+    let mut where_started = false;
+    let mut push_condition = |query: &mut QueryBuilder<Postgres>| {
+        query.push(if where_started { " AND " } else { " WHERE " });
+        where_started = true;
+    };
+
+    if let Some(collectors) = collectors
+        .as_ref()
+        .filter(|collectors| !collectors.is_empty())
+    {
+        push_condition(query);
+        query.push("collector_name IN (");
+        let mut separated = query.separated(", ");
+        for collector in collectors {
+            separated.push_bind(collector);
+        }
+        separated.push_unseparated(")");
+    }
+    if let Some(project) = project {
+        let project =
+            normalize_project(project).expect("validated before building PostgreSQL query");
+        push_condition(query);
+        query.push("project_name = ").push_bind(project);
+    }
+    if let Some(data_type) = data_type {
+        push_condition(query);
+        query.push("type = ").push_bind(data_type);
+    }
+    if let Some(start) = ts_start {
+        let start = start.and_utc();
+        push_condition(query);
+        query
+            .push("((project_name = 'ripe-ris' AND type = 'updates' AND timestamp > ")
+            .push_bind(start - Duration::minutes(5))
+            .push(") OR (project_name = 'route-views' AND type = 'updates' AND timestamp > ")
+            .push_bind(start - Duration::minutes(15))
+            .push(") OR (type = 'rib' AND timestamp >= ")
+            .push_bind(start)
+            .push("))");
+    }
+    if let Some(end) = ts_end {
+        push_condition(query);
+        query.push("timestamp < ").push_bind(end.and_utc());
+    }
+}
+
+fn pg_row_to_item(
+    row: PgRow,
+    collector_map: &HashMap<String, BrokerCollector>,
+) -> Option<BrokerItem> {
+    let collector_name: String = row.get("collector_name");
+    let collector = collector_map.get(&collector_name)?;
+    let timestamp: DateTime<Utc> = row.get("timestamp");
+    let data_type: String = row.get("type");
+    let (url, ts_end) = infer_url(collector, &timestamp.naive_utc(), data_type == "rib");
+    Some(BrokerItem {
+        ts_start: timestamp.naive_utc(),
+        ts_end,
+        collector_id: collector_name,
+        data_type,
+        url,
+        rough_size: row.get("rough_size"),
+        exact_size: row.get("exact_size"),
+    })
+}
+
+fn row_to_item(row: PgRow, collector: &BrokerCollector) -> BrokerItem {
+    let timestamp: DateTime<Utc> = row.get("ts_start");
+    let data_type: String = row.get("data_type");
+    let (url, ts_end) = infer_url(collector, &timestamp.naive_utc(), data_type == "rib");
+    BrokerItem {
+        ts_start: timestamp.naive_utc(),
+        ts_end,
+        collector_id: collector.name.clone(),
+        data_type,
+        url,
+        rough_size: row.get("rough_size"),
+        exact_size: row.get("exact_size"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    #[ignore = "requires BGPKIT_BROKER_TEST_POSTGRES_URL and a bootstrap schema"]
+    async fn postgres_catalog_writes_update_latest_and_meta(
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let database_url = std::env::var("BGPKIT_BROKER_TEST_POSTGRES_URL")?;
+        let database = PostgresDb::new(&database_url).await?;
+        database.cleanup_old_meta_entries(0).await?;
+        let timestamp = DateTime::from_timestamp(1_704_067_500, 0)
+            .ok_or_else(|| std::io::Error::other("test timestamp is invalid"))?
+            .naive_utc();
+        let item = BrokerItem {
+            ts_start: timestamp,
+            ts_end: timestamp + Duration::seconds(300),
+            collector_id: "rrc00".to_string(),
+            data_type: "updates".to_string(),
+            url: "https://example.invalid/updates.20240101.0000.gz".to_string(),
+            rough_size: 56,
+            exact_size: 78,
+        };
+
+        let inserted = database.insert_items(&[item], true).await?;
+        assert_eq!(inserted.len(), 1);
+        assert_eq!(database.get_latest_files().await.len(), 1);
+        assert!(database.get_latest_updates_meta().await?.is_none());
+        assert_eq!(database.insert_meta(3, 1).await?.len(), 1);
+        assert_eq!(
+            database
+                .get_latest_updates_meta()
+                .await?
+                .map(|meta| meta.insert_count),
+            Some(1)
+        );
+        database.cleanup_old_meta_entries(0).await?;
+        assert!(database.get_latest_updates_meta().await?.is_none());
+        Ok(())
+    }
+
+    #[test]
+    fn exact_timestamp_search_includes_one_second() {
+        let timestamp = DateTime::from_timestamp(1_700_000_000, 0)
+            .unwrap_or(DateTime::UNIX_EPOCH)
+            .naive_utc();
+        assert_eq!(
+            normalize_search_end(Some(timestamp), Some(timestamp)),
+            Some(timestamp + Duration::seconds(1))
+        );
+    }
+}

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -1,4 +1,7 @@
-use super::{DbSearchResult, UpdatesMeta, DEFAULT_PAGE_SIZE};
+use super::{
+    DbSearchResult, UpdatesMeta, DEFAULT_PAGE_SIZE, UPDATES_LOOKBACK_RIPE_RIS_SECS,
+    UPDATES_LOOKBACK_ROUTE_VIEWS_SECS,
+};
 use crate::db::utils::infer_url;
 use crate::query::BrokerCollector;
 use crate::{BrokerError, BrokerItem, Collector};
@@ -7,6 +10,7 @@ use sqlx::postgres::{PgPoolOptions, PgRow};
 use sqlx::{PgPool, Postgres, QueryBuilder, Row};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
+use tracing::error;
 
 /// PostgreSQL adapter for a Broker catalog initialized with
 /// `migration/postgres_bootstrap/bootstrap.py`.
@@ -21,9 +25,9 @@ pub struct PostgresDb {
 }
 
 impl PostgresDb {
-    pub async fn new(database_url: &str) -> Result<Self, BrokerError> {
+    pub async fn new(database_url: &str, max_connections: u32) -> Result<Self, BrokerError> {
         let conn_pool = PgPoolOptions::new()
-            .max_connections(10)
+            .max_connections(max_connections)
             .connect(database_url)
             .await
             .map_err(database_error)?;
@@ -139,11 +143,17 @@ impl PostgresDb {
         .await
         {
             Ok(rows) => rows,
-            Err(_) => return Vec::new(),
+            Err(e) => {
+                error!("failed to get latest files: {}", e);
+                return Vec::new();
+            }
         };
         let collector_map = match self.collector_map() {
             Ok(collectors) => collectors,
-            Err(_) => return Vec::new(),
+            Err(e) => {
+                error!("failed to get collector map for latest files: {}", e);
+                return Vec::new();
+            }
         };
         rows.into_iter()
             .filter_map(|row| pg_row_to_item(row, &collector_map))
@@ -191,17 +201,25 @@ impl PostgresDb {
         let collector_map = self.collector_map()?;
         let mut inserted = Vec::new();
         for batch in items.chunks(1000) {
+            // Filter out items whose collector is not in the cache, matching the
+            // SQLite backend's filter_map behavior. Binding None for an unknown
+            // collector would violate the NOT NULL constraint and fail the entire
+            // batch insert.
+            let resolvable: Vec<&BrokerItem> = batch
+                .iter()
+                .filter(|item| collector_map.contains_key(item.collector_id.as_str()))
+                .collect();
+            if resolvable.is_empty() {
+                continue;
+            }
             let mut query = QueryBuilder::<Postgres>::new(
                 "INSERT INTO mrt.file (ts_start, collector_id, data_type, rough_size, exact_size) ",
             );
-            query.push_values(batch, |mut values, item| {
+            query.push_values(resolvable.iter(), |mut values, item| {
+                let collector_id = collector_map[item.collector_id.as_str()].id;
                 values
                     .push_bind(item.ts_start.and_utc())
-                    .push_bind(
-                        collector_map
-                            .get(item.collector_id.as_str())
-                            .map(|collector| collector.id),
-                    )
+                    .push_bind(collector_id)
                     .push_bind(item.data_type.as_str())
                     .push_bind(item.rough_size)
                     .push_bind(item.exact_size);
@@ -406,6 +424,13 @@ fn normalize_data_type(data_type: Option<&str>) -> Result<Option<&str>, BrokerEr
     }
 }
 
+/// Normalize the search end timestamp.
+///
+/// When `ts_start` and `ts_end` are identical, expand `ts_end` by one second so
+/// the given timestamp is always included in the result set. This mirrors the
+/// inline logic in `LocalBrokerDb::search` (db/mod.rs); the SQLite path applies
+/// the same +1-second rule but does so inside its match arms rather than via a
+/// helper. Both backends must keep this behavior in sync.
 fn normalize_search_end(
     ts_start: Option<NaiveDateTime>,
     ts_end: Option<NaiveDateTime>,
@@ -457,9 +482,9 @@ fn apply_search_filters(
         push_condition(query);
         query
             .push("((project_name = 'ripe-ris' AND type = 'updates' AND timestamp > ")
-            .push_bind(start - Duration::minutes(5))
+            .push_bind(start - Duration::seconds(UPDATES_LOOKBACK_RIPE_RIS_SECS))
             .push(") OR (project_name = 'route-views' AND type = 'updates' AND timestamp > ")
-            .push_bind(start - Duration::minutes(15))
+            .push_bind(start - Duration::seconds(UPDATES_LOOKBACK_ROUTE_VIEWS_SECS))
             .push(") OR (type = 'rib' AND timestamp >= ")
             .push_bind(start)
             .push("))");
@@ -514,7 +539,7 @@ mod tests {
     async fn postgres_catalog_writes_update_latest_and_meta(
     ) -> Result<(), Box<dyn std::error::Error>> {
         let database_url = std::env::var("BGPKIT_BROKER_TEST_POSTGRES_URL")?;
-        let database = PostgresDb::new(&database_url).await?;
+        let database = PostgresDb::new(&database_url, 10).await?;
         let collector = Collector {
             id: "pg-runtime-test".to_string(),
             project: "riperis".to_string(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,11 +227,13 @@ use chrono::{DateTime, NaiveDate, TimeZone, Utc};
 pub use collector::{load_collectors, Collector};
 
 #[cfg(feature = "cli")]
-pub use config::BrokerConfig;
+pub use config::{BrokerConfig, DatabaseTarget};
 #[cfg(feature = "cli")]
 pub use crawler::crawl_collector;
+#[cfg(feature = "cli")]
+pub use db::DatabaseBackend;
 #[cfg(feature = "backend")]
-pub use db::{LocalBrokerDb, UpdatesMeta, DEFAULT_PAGE_SIZE};
+pub use db::{LocalBrokerDb, PostgresDb, UpdatesMeta, DEFAULT_PAGE_SIZE};
 pub use error::BrokerError;
 pub use item::BrokerItem;
 pub use peer::BrokerPeer;
@@ -415,7 +417,11 @@ impl BgpkitBroker {
 
         let mut hasher = Sha256::new();
         hasher.update(params_str.as_bytes());
-        hasher.finalize().iter().map(|b| format!("{:02x}", b)).collect::<String>()
+        hasher
+            .finalize()
+            .iter()
+            .map(|b| format!("{:02x}", b))
+            .collect::<String>()
     }
 
     /// Try to load cached results for current query parameters.


### PR DESCRIPTION
## Summary
- add an explicit, opt-in PostgreSQL backend selected by `BGPKIT_BROKER_POSTGRES_URL` or a positional `pg://`/`postgresql://` URL; SQLite remains the default and `BGPKIT_BROKER_SQLITE_PATH` selects a custom SQLite file;
- add PostgreSQL catalog search/latest, crawler writes, latest-file maintenance, and SQLite-compatible update metadata;
- add a SQLite-to-PostgreSQL bootstrap utility and document operational selection and backup boundaries;
- keep credentials runtime-supplied and redact PostgreSQL URLs from configuration debug output.

## Design
- PostgreSQL uses the same operational catalog model as SQLite (`mrt.file`, `mrt.latest_file`, `mrt.update_meta`); it does not introduce source-revision or ingest-run provenance tables.
- One PostgreSQL URL supports either API+crawler operation or API-only operation with `--no-update`.
- SQLite file backup behavior is retained only for SQLite; PostgreSQL backup/replication remains database-native.

## Validation
- `cargo build --verbose`
- `cargo build --features cli --verbose`
- `cargo check --features backend`
- `cargo test --no-default-features --verbose`
- `cargo test --features cli --verbose`
- `cargo clippy --all-features -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- `python3 -m unittest migration/postgres_bootstrap/tests/test_bootstrap.py -v`
- `docker compose config` with both an empty and a supplied PostgreSQL URL
- `docker build -t bgpkit-broker:postgres-config-check .`
- a container help invocation with `BGPKIT_BROKER_POSTGRES_URL` supplied at runtime
- fresh SQLite-fixture bootstrap into PostgreSQL, plus the ignored PostgreSQL runtime write integration test (`insert → collector/latest update → update metadata`)

## Notes
- This is a draft for review; no production PostgreSQL deployment or data job was modified.