### PR TITLE
fix: bound SQLite connection pool memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ All notable changes to this project will be documented in this file.
     * Added default 30-day time window when neither `ts_start` nor `ts_end` is specified
     * Prevents full table scans that caused timeouts on large databases
     * Returns recent data by default instead of starting from 1970
+* Bounded SQLite connection-pool memory usage (fixes #101)
+    * Reduced the default maximum from 10 to 2 connections per pool
+    * Set SQLite's suggested per-connection page-cache maximum to 640 KiB
+    * Added `BGPKIT_BROKER_SQLITE_MAX_CONNECTIONS` and `BGPKIT_BROKER_SQLITE_CACHE_SIZE_KIB` overrides
 
 ## v0.11.0 - 2025-03-23
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,8 @@ Cache files are stored as JSON in the specified directory. The cache key is gene
 - `BGPKIT_BROKER_META_RETENTION_DAYS` - Number of days to retain meta entries (default: 30)
 - `BGPKIT_BROKER_POSTGRES_URL` - Explicit PostgreSQL catalog URL for the `serve` API. SQLite remains the default; PostgreSQL supports the same crawler/update lifecycle when an update-capable URL is supplied. Initialize a new PostgreSQL catalog first with [`migration/postgres_bootstrap/bootstrap.py`](migration/postgres_bootstrap/README.md).
 - `BGPKIT_BROKER_SQLITE_PATH` - SQLite catalog file path when neither a database path/URL argument nor PostgreSQL configuration is supplied. Default: `bgpkit-broker.sqlite3`.
+- `BGPKIT_BROKER_SQLITE_MAX_CONNECTIONS` - Maximum number of connections in each SQLite pool (default: 2). Increase this only when measured query concurrency requires it; every connection has a dedicated worker thread and private caches.
+- `BGPKIT_BROKER_SQLITE_CACHE_SIZE_KIB` - SQLite's suggested per-connection page-cache maximum in KiB (default: 640).
 - `BGPKIT_BROKER_POSTGRES_MAX_CONNECTIONS` - Maximum number of connections in the PostgreSQL pool (default: 10).
 
 ### Data Structures

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,6 +7,8 @@
 use std::fmt;
 use std::time::Duration;
 
+use crate::db::sqlite_pool_config;
+
 /// Default values for crawler configuration
 const DEFAULT_CRAWLER_MAX_RETRIES: u32 = 3;
 const DEFAULT_CRAWLER_BACKOFF_MS: u64 = 1000;
@@ -407,9 +409,10 @@ impl BrokerConfig {
         }
 
         // Database maintenance
+        let (sqlite_max_connections, sqlite_cache_size_kib) = sqlite_pool_config();
         lines.push(format!(
-            "Database: meta_retention_days={}",
-            self.database.meta_retention_days
+            "Database: meta_retention_days={}, sqlite_max_connections={}, sqlite_cache_size_kib={}",
+            self.database.meta_retention_days, sqlite_max_connections, sqlite_cache_size_kib
         ));
 
         lines.push("=====================================".to_string());

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -15,16 +15,47 @@ use crate::db::utils::infer_url;
 use crate::query::{BrokerCollector, BrokerItemType};
 use crate::{BrokerError, BrokerItem, Collector};
 use chrono::{DateTime, Duration, NaiveDateTime};
-use sqlx::sqlite::SqliteRow;
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePoolOptions, SqliteRow};
 use sqlx::Row;
 use sqlx::SqlitePool;
 use sqlx::{migrate::MigrateDatabase, Sqlite};
 use std::collections::HashMap;
+use std::str::FromStr;
 use tracing::{debug, error, info};
 
 pub use meta::UpdatesMeta;
 
 pub const DEFAULT_PAGE_SIZE: usize = 100;
+
+const DEFAULT_SQLITE_MAX_CONNECTIONS: u32 = 2;
+const DEFAULT_SQLITE_CACHE_SIZE_KIB: u32 = 640;
+const MAX_SQLITE_CACHE_SIZE_KIB: u32 = (i32::MAX as u32) + 1;
+
+fn bounded_positive_env_u32(name: &str, default: u32, maximum: u32) -> u32 {
+    bounded_positive_u32(std::env::var(name).ok().as_deref(), default, maximum)
+}
+
+fn bounded_positive_u32(value: Option<&str>, default: u32, maximum: u32) -> u32 {
+    value
+        .and_then(|value| value.parse().ok())
+        .filter(|value| (1..=maximum).contains(value))
+        .unwrap_or(default)
+}
+
+pub(crate) fn sqlite_pool_config() -> (u32, u32) {
+    (
+        bounded_positive_env_u32(
+            "BGPKIT_BROKER_SQLITE_MAX_CONNECTIONS",
+            DEFAULT_SQLITE_MAX_CONNECTIONS,
+            u32::MAX,
+        ),
+        bounded_positive_env_u32(
+            "BGPKIT_BROKER_SQLITE_CACHE_SIZE_KIB",
+            DEFAULT_SQLITE_CACHE_SIZE_KIB,
+            MAX_SQLITE_CACHE_SIZE_KIB,
+        ),
+    )
+}
 
 /// Update-file lookback window for RIPE RIS collectors, in seconds.
 /// RIPE RIS publishes update files every 5 minutes.
@@ -67,6 +98,15 @@ fn get_ts_end_clause(ts: i64) -> String {
 
 impl LocalBrokerDb {
     pub async fn new(path: &str) -> Result<Self, BrokerError> {
+        let (max_connections, cache_size_kib) = sqlite_pool_config();
+        Self::new_with_pool_options(path, max_connections, cache_size_kib).await
+    }
+
+    pub(crate) async fn new_with_pool_options(
+        path: &str,
+        max_connections: u32,
+        cache_size_kib: u32,
+    ) -> Result<Self, BrokerError> {
         info!("open local broker db at {}", path);
 
         if !Sqlite::database_exists(path).await? {
@@ -75,7 +115,17 @@ impl LocalBrokerDb {
                 Err(error) => panic!("error: {}", error),
             }
         }
-        let conn_pool = SqlitePool::connect(path).await?;
+
+        // SQLite serializes writes at the file level. Keeping the pool small
+        // avoids duplicated page caches, statement caches, and worker threads.
+        // Keep mmap disabled: faulted pages count toward process RSS.
+        let conn_pool = SqlitePoolOptions::new()
+            .max_connections(max_connections)
+            .connect_with(
+                SqliteConnectOptions::from_str(path)?
+                    .pragma("cache_size", format!("-{cache_size_kib}")),
+            )
+            .await?;
 
         let mut db = LocalBrokerDb {
             conn_pool,
@@ -570,6 +620,55 @@ mod tests {
         if shm_path.exists() {
             let _ = std::fs::remove_file(shm_path);
         }
+    }
+
+    #[tokio::test]
+    async fn test_sqlite_pool_options() -> Result<(), BrokerError> {
+        let db_path = create_temp_db_path("pool_options");
+        let db_path_string = db_path.to_string_lossy();
+        let db = LocalBrokerDb::new_with_pool_options(&db_path_string, 3, 512).await?;
+
+        assert_eq!(db.conn_pool.options().get_max_connections(), 3);
+
+        // Hold all three connections at once so the pool has to create each
+        // one, then verify the connection-level PRAGMA on every worker.
+        let mut connections = Vec::new();
+        for _ in 0..3 {
+            let mut connection = db.conn_pool.acquire().await?;
+            let cache_size = sqlx::query("PRAGMA cache_size")
+                .map(|row: SqliteRow| row.get::<i64, _>(0))
+                .fetch_one(&mut *connection)
+                .await?;
+            assert_eq!(cache_size, -512);
+            connections.push(connection);
+        }
+
+        drop(connections);
+        drop(db);
+        cleanup_db_file(&db_path);
+        Ok(())
+    }
+
+    #[test]
+    fn test_bounded_positive_u32_config_value() {
+        assert_eq!(bounded_positive_u32(Some("4"), 2, u32::MAX), 4);
+        assert_eq!(bounded_positive_u32(Some("0"), 2, u32::MAX), 2);
+        assert_eq!(bounded_positive_u32(Some("invalid"), 2, u32::MAX), 2);
+        assert_eq!(bounded_positive_u32(Some("4294967296"), 2, u32::MAX), 2);
+        assert_eq!(bounded_positive_u32(None, 2, u32::MAX), 2);
+
+        assert_eq!(
+            bounded_positive_u32(Some("2147483648"), 640, MAX_SQLITE_CACHE_SIZE_KIB),
+            2_147_483_648
+        );
+        assert_eq!(
+            bounded_positive_u32(Some("2147483649"), 640, MAX_SQLITE_CACHE_SIZE_KIB),
+            640
+        );
+        assert_eq!(
+            bounded_positive_u32(Some("4294967295"), 640, MAX_SQLITE_CACHE_SIZE_KIB),
+            640
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Solution

- Build each local SQLite pool with `SqlitePoolOptions` instead of the sqlx default pool configuration.
- Default each pool to 2 connections and set SQLite's suggested per-connection page-cache maximum to 640 KiB.
- Add bounded runtime overrides:
  - `BGPKIT_BROKER_SQLITE_MAX_CONNECTIONS`
  - `BGPKIT_BROKER_SQLITE_CACHE_SIZE_KIB`
- Fall back to safe defaults for absent, zero, malformed, or cache-size values outside SQLite's supported signed `PRAGMA cache_size` range.
- Preserve existing public database constructor signatures and standalone `backend` feature support.
- Document the settings in README and CHANGELOG.

## Evidence for the selected defaults

The deterministic update-and-backup workload isolated pool width from cache size:

| SQLite setting | Peak RSS | Final RSS |
|---|---:|---:|
| 10 connections, default cache | 226.86 MiB | 226.18 MiB |
| 10 connections, 640 KiB cache | 220.19 MiB | 219.98 MiB |
| 2 connections, default cache | 96.48 MiB | 88.06 MiB |
| 2 connections, 640 KiB cache | 92.35 MiB | 82.41 MiB |

The selected default reduced final RSS by 63.6%. Under the concurrent API control it reduced peak RSS by 60.1%, with 0 request errors and a measured 13.9% throughput reduction. Deployments requiring greater query concurrency can raise the connection override; 4 connections recovered essentially all measured throughput while retaining lower RSS.

The final change intentionally does not alter the allocator, SQLite durability/checkpoint behavior, backup handling, data retention, or HTTP-client lifecycle.

## Regression coverage

- Verify the configured pool maximum.
- Hold every connection concurrently and verify `PRAGMA cache_size` on each one.
- Cover valid, zero, malformed, absent, and SQLite boundary/out-of-range configuration values.
- Exercise the standalone `backend` feature to preserve the existing feature/API contract.

## Validation

- `cargo fmt --check`
- `cargo build --no-default-features`
- `cargo check --no-default-features --features backend`
- `cargo build --features cli`
- `cargo test --all-features` — 60 library tests passed, 1 PostgreSQL integration test ignored by design; 4 CLI tests and 62 doctests passed
- `cargo clippy --all-features -- -D warnings`

Closes #101
