### PR TITLE
fix: survive transient database outages in serve

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,6 +323,8 @@ Cache files are stored as JSON in the specified directory. The cache key is gene
 - `BGPKIT_BROKER_SQLITE_MAX_CONNECTIONS` - Maximum number of connections in each SQLite pool (default: 2). Increase this only when measured query concurrency requires it; every connection has a dedicated worker thread and private caches.
 - `BGPKIT_BROKER_SQLITE_CACHE_SIZE_KIB` - SQLite's suggested per-connection page-cache maximum in KiB (default: 640).
 - `BGPKIT_BROKER_POSTGRES_MAX_CONNECTIONS` - Maximum number of connections in the PostgreSQL pool (default: 10).
+- `BGPKIT_BROKER_DB_CONNECT_RETRIES` - Maximum connection attempts before the serve command gives up; each attempt waits with exponential backoff (default: 10).
+- `BGPKIT_BROKER_DB_CONNECT_BACKOFF_MS` - Initial backoff in milliseconds between database connection attempts; doubles after each failure (default: 3000).
 
 ### Data Structures
 

--- a/src/cli/api.rs
+++ b/src/cli/api.rs
@@ -278,7 +278,19 @@ async fn latest(
     query: Query<BrokerLatestQuery>,
     State(state): State<Arc<AppState>>,
 ) -> impl IntoResponse {
-    let mut items = state.database.get_latest_files().await;
+    let mut items = match state.database.get_latest_files().await {
+        Ok(items) => items,
+        Err(e) => {
+            error!("failed to get latest files: {}", e);
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(BrokerApiError::BrokerNotHealthy(
+                    "database connection error".to_string(),
+                )),
+            )
+                .into_response();
+        }
+    };
     if let Some(collector_ids) = &query.collector_id {
         let wanted = collector_ids
             .split(',')
@@ -307,6 +319,7 @@ async fn latest(
         data: items,
         meta,
     })
+    .into_response()
 }
 
 /// Return Broker API and database health
@@ -365,7 +378,19 @@ async fn health(
 }
 
 async fn missing_collectors(State(state): State<Arc<AppState>>) -> impl IntoResponse {
-    let latest_items = state.database.get_latest_files().await;
+    let latest_items = match state.database.get_latest_files().await {
+        Ok(items) => items,
+        Err(e) => {
+            error!("failed to get latest files: {}", e);
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(BrokerApiError::BrokerNotHealthy(
+                    "database connection error".to_string(),
+                )),
+            )
+                .into_response();
+        }
+    };
     let missing_collectors = get_missing_collectors(&latest_items);
 
     match missing_collectors.is_empty() {

--- a/src/cli/main.rs
+++ b/src/cli/main.rs
@@ -8,6 +8,7 @@ use crate::api::{start_api_service, BrokerSearchQuery};
 use crate::backup::{backup_database, perform_periodic_backup};
 use crate::bootstrap::download_file;
 use crate::utils::{get_missing_collectors, is_local_path, parse_s3_path};
+use bgpkit_broker::db::ConnectRetryConfig;
 use bgpkit_broker::{
     crawl_collector, load_collectors, BgpkitBroker, BrokerConfig, BrokerError, BrokerItem,
     Collector, DatabaseBackend, DatabaseTarget, LocalBrokerDb, DEFAULT_PAGE_SIZE,
@@ -294,12 +295,23 @@ async fn update_database(
     let start_time = Instant::now();
     let now = Utc::now();
 
-    let latest_ts_map: HashMap<String, NaiveDateTime> = db
-        .get_latest_files()
-        .await
-        .into_iter()
-        .map(|f| (f.collector_id.clone(), f.ts_start))
-        .collect();
+    let latest_ts_map: HashMap<String, NaiveDateTime> = match db.get_latest_files().await {
+        Ok(files) => files
+            .into_iter()
+            .map(|f| (f.collector_id.clone(), f.ts_start))
+            .collect(),
+        Err(e) => {
+            // A failed read here previously produced an empty map, which the
+            // crawler treated as an empty database and answered with a full
+            // bootstrap crawl of every collector. Skip this update round
+            // instead and retry on the next interval.
+            error!(
+                "failed to read latest files, skipping this update round: {}",
+                e
+            );
+            return;
+        }
+    };
 
     let mut collector_updated = false;
     for c in &collectors {
@@ -579,9 +591,15 @@ fn main() {
                         }
                     };
                     rt.block_on(async {
-                        let mut db = match DatabaseBackend::connect(
+                        let mut db = match DatabaseBackend::connect_with_retry(
                             &database_target_clone,
                             config_clone.database.postgres_max_connections,
+                            ConnectRetryConfig {
+                                max_attempts: config_clone.database.db_connect_retries.max(1),
+                                initial_backoff: std::time::Duration::from_millis(
+                                    config_clone.database.db_connect_backoff_ms,
+                                ),
+                            },
                         )
                         .await
                         {
@@ -721,9 +739,15 @@ fn main() {
                             exit(1);
                         }
                     }
-                    let database = match DatabaseBackend::connect(
+                    let database = match DatabaseBackend::connect_with_retry(
                         &database_target,
                         config.database.postgres_max_connections,
+                        ConnectRetryConfig {
+                            max_attempts: config.database.db_connect_retries.max(1),
+                            initial_backoff: std::time::Duration::from_millis(
+                                config.database.db_connect_backoff_ms,
+                            ),
+                        },
                     )
                     .await
                     {

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,6 +21,8 @@ const DEFAULT_BACKUP_INTERVAL_HOURS: u64 = 24;
 /// Default values for database maintenance
 const DEFAULT_META_RETENTION_DAYS: i64 = 30;
 const DEFAULT_POSTGRES_MAX_CONNECTIONS: u32 = 10;
+const DEFAULT_DB_CONNECT_RETRIES: u32 = 10;
+const DEFAULT_DB_CONNECT_BACKOFF_MS: u64 = 3000;
 
 /// Crawler configuration settings.
 ///
@@ -253,6 +255,13 @@ pub struct DatabaseConfig {
     /// Maximum number of connections in the PostgreSQL pool.
     /// Environment variable: `BGPKIT_BROKER_POSTGRES_MAX_CONNECTIONS`
     pub postgres_max_connections: u32,
+    /// Maximum connection attempts before the serve command gives up and exits.
+    /// Environment variable: `BGPKIT_BROKER_DB_CONNECT_RETRIES`
+    pub db_connect_retries: u32,
+    /// Initial backoff between connection attempts, in milliseconds. The delay
+    /// doubles after each failed attempt (1x, 2x, 4x, ...).
+    /// Environment variable: `BGPKIT_BROKER_DB_CONNECT_BACKOFF_MS`
+    pub db_connect_backoff_ms: u64,
 }
 
 impl fmt::Debug for DatabaseConfig {
@@ -277,6 +286,8 @@ impl Default for DatabaseConfig {
             postgres_url: None,
             sqlite_path: None,
             postgres_max_connections: DEFAULT_POSTGRES_MAX_CONNECTIONS,
+            db_connect_retries: DEFAULT_DB_CONNECT_RETRIES,
+            db_connect_backoff_ms: DEFAULT_DB_CONNECT_BACKOFF_MS,
         }
     }
 }
@@ -295,6 +306,14 @@ impl DatabaseConfig {
                 .ok()
                 .and_then(|s| s.parse().ok())
                 .unwrap_or(DEFAULT_POSTGRES_MAX_CONNECTIONS),
+            db_connect_retries: std::env::var("BGPKIT_BROKER_DB_CONNECT_RETRIES")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(DEFAULT_DB_CONNECT_RETRIES),
+            db_connect_backoff_ms: std::env::var("BGPKIT_BROKER_DB_CONNECT_BACKOFF_MS")
+                .ok()
+                .and_then(|s| s.parse().ok())
+                .unwrap_or(DEFAULT_DB_CONNECT_BACKOFF_MS),
         }
     }
 }
@@ -434,6 +453,8 @@ mod tests {
         assert_eq!(config.crawler.month_concurrency, 2);
         assert_eq!(config.backup.interval_hours, 24);
         assert_eq!(config.database.meta_retention_days, 30);
+        assert_eq!(config.database.db_connect_retries, 10);
+        assert_eq!(config.database.db_connect_backoff_ms, 3000);
         assert!(!config.backup.is_enabled());
     }
 

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -2,11 +2,35 @@ use super::{DbSearchResult, LocalBrokerDb, PostgresDb, UpdatesMeta};
 use crate::config::DatabaseTarget;
 use crate::{BrokerError, BrokerItem, Collector};
 use chrono::NaiveDateTime;
+use std::time::Duration;
+use tracing::{error, info};
 
 #[derive(Clone)]
 pub enum DatabaseBackend {
     Sqlite(LocalBrokerDb),
     Postgres(PostgresDb),
+}
+
+/// Connection retry parameters for the serve command.
+#[derive(Debug, Clone, Copy)]
+pub struct ConnectRetryConfig {
+    /// Maximum number of connection attempts.
+    pub max_attempts: u32,
+    /// Initial delay between attempts; doubles after each failure.
+    pub initial_backoff: Duration,
+}
+
+impl ConnectRetryConfig {
+    /// Delay before the attempt with the given one-based index, assuming all
+    /// previous attempts failed. Grows exponentially from the initial backoff
+    /// and saturates to `None` once the wait exceeds `Duration::MAX`.
+    fn backoff_before_attempt(&self, attempt: u32) -> Option<Duration> {
+        if attempt == 0 {
+            return Some(Duration::ZERO);
+        }
+        let shift = (attempt - 1).min(u32::BITS - 1);
+        self.initial_backoff.checked_mul(1_u32 << shift)
+    }
 }
 
 impl DatabaseBackend {
@@ -19,6 +43,57 @@ impl DatabaseBackend {
             DatabaseTarget::Postgres(url) => PostgresDb::new(url, max_connections)
                 .await
                 .map(Self::Postgres),
+        }
+    }
+
+    /// Connect to the database, retrying with exponential backoff while the
+    /// server is unavailable. The serve command is expected to survive database
+    /// restarts (for example a PostgreSQL maintenance reboot), so a transient
+    /// connect failure must not kill the process.
+    pub async fn connect_with_retry(
+        target: &DatabaseTarget,
+        max_connections: u32,
+        retry: ConnectRetryConfig,
+    ) -> Result<Self, BrokerError> {
+        let mut attempt: u32 = 0;
+        loop {
+            match Self::connect(target, max_connections).await {
+                Ok(db) => {
+                    if attempt > 0 {
+                        info!("database connection established on attempt {}", attempt + 1);
+                    }
+                    return Ok(db);
+                }
+                Err(e) => {
+                    if attempt + 1 >= retry.max_attempts {
+                        error!(
+                            "failed to connect to database after {} attempts: {}",
+                            retry.max_attempts, e
+                        );
+                        return Err(e);
+                    }
+                    attempt += 1;
+                    match retry.backoff_before_attempt(attempt) {
+                        Some(backoff) => {
+                            error!(
+                                "failed to connect to database (attempt {}/{}): {}; retrying in {:?}",
+                                attempt, retry.max_attempts, e, backoff
+                            );
+                            tokio::time::sleep(backoff).await;
+                        }
+                        None => {
+                            // Exponential growth overflowed; cap the wait instead
+                            // of spinning without delay.
+                            let backoff = retry.initial_backoff;
+                            error!(
+                                "database connect backoff overflowed at attempt {}; retrying in {:?}",
+                                attempt, backoff
+                            );
+                            tokio::time::sleep(backoff).await;
+                        }
+                    }
+                }
+            }
         }
     }
 
@@ -93,7 +168,7 @@ impl DatabaseBackend {
         }
     }
 
-    pub async fn get_latest_files(&self) -> Vec<BrokerItem> {
+    pub async fn get_latest_files(&self) -> Result<Vec<BrokerItem>, BrokerError> {
         match self {
             Self::Sqlite(database) => database.get_latest_files().await,
             Self::Postgres(database) => database.get_latest_files().await,
@@ -137,5 +212,96 @@ impl DatabaseBackend {
             Self::Sqlite(database) => database.cleanup_old_meta_entries().await.map(|_| ()),
             Self::Postgres(database) => database.cleanup_old_meta_entries(retention_days).await,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn connect_with_retry_exhausts_attempts_and_returns_error() {
+        // A SQLite path whose parent directory is read-only fails fast, which
+        // mirrors the production failure mode (database unavailable) without
+        // waiting on TCP timeouts. The retry loop must surface the final
+        // error after exhausting attempts instead of hanging or panicking.
+        use std::os::unix::fs::PermissionsExt;
+
+        let dir = tempfile::tempdir().unwrap();
+        let ro = dir.path().join("ro");
+        std::fs::create_dir(&ro).unwrap();
+        let db_path = ro.join("sub").join("broker.sqlite3");
+
+        let mut perms = std::fs::metadata(&ro).unwrap().permissions();
+        perms.set_mode(0o555);
+        std::fs::set_permissions(&ro, perms).unwrap();
+
+        let target = DatabaseTarget::Sqlite(db_path.to_str().unwrap().to_string());
+        let retry = ConnectRetryConfig {
+            max_attempts: 3,
+            initial_backoff: Duration::from_millis(10),
+        };
+        let result = DatabaseBackend::connect_with_retry(&target, 2, retry).await;
+        assert!(result.is_err());
+
+        // Restore permissions so tempfile can clean up.
+        let mut perms = std::fs::metadata(&ro).unwrap().permissions();
+        perms.set_mode(0o755);
+        std::fs::set_permissions(&ro, perms).unwrap();
+    }
+
+    #[tokio::test]
+    async fn connect_with_retry_succeeds_when_database_is_available() {
+        let dir = tempfile::tempdir().unwrap();
+        let mut db_path = dir.path().to_path_buf();
+        db_path.push("broker.sqlite3");
+        let target = DatabaseTarget::Sqlite(db_path.to_str().unwrap().to_string());
+        let retry = ConnectRetryConfig {
+            max_attempts: 3,
+            initial_backoff: Duration::from_millis(10),
+        };
+        assert!(DatabaseBackend::connect_with_retry(&target, 2, retry)
+            .await
+            .is_ok());
+    }
+
+    #[test]
+    fn connect_backoff_grows_exponentially() {
+        let retry = ConnectRetryConfig {
+            max_attempts: 10,
+            initial_backoff: Duration::from_millis(3000),
+        };
+        // The first retry waits one initial backoff, then it doubles.
+        assert_eq!(
+            retry.backoff_before_attempt(1),
+            Some(Duration::from_millis(3000))
+        );
+        assert_eq!(
+            retry.backoff_before_attempt(2),
+            Some(Duration::from_millis(6000))
+        );
+        assert_eq!(
+            retry.backoff_before_attempt(3),
+            Some(Duration::from_millis(12_000))
+        );
+        assert_eq!(
+            retry.backoff_before_attempt(4),
+            Some(Duration::from_millis(24_000))
+        );
+    }
+
+    #[test]
+    fn connect_backoff_overflow_returns_none_instead_of_panicking() {
+        let retry = ConnectRetryConfig {
+            max_attempts: u32::MAX,
+            initial_backoff: Duration::MAX / 4,
+        };
+        // Doubling stays representable for the first few attempts...
+        assert_eq!(retry.backoff_before_attempt(1), Some(Duration::MAX / 4));
+        // ...until the multiplication exceeds Duration::MAX, which must
+        // return None rather than panic.
+        assert!(retry.backoff_before_attempt(2).is_some());
+        assert!(retry.backoff_before_attempt(3).is_some());
+        assert_eq!(retry.backoff_before_attempt(33), None);
     }
 }

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -22,14 +22,17 @@ pub struct ConnectRetryConfig {
 
 impl ConnectRetryConfig {
     /// Delay before the attempt with the given one-based index, assuming all
-    /// previous attempts failed. Grows exponentially from the initial backoff
-    /// and saturates to `None` once the wait exceeds `Duration::MAX`.
+    /// previous attempts failed. Doubles after each failure and returns
+    /// `None` once the wait would exceed `Duration::MAX`.
     fn backoff_before_attempt(&self, attempt: u32) -> Option<Duration> {
         if attempt == 0 {
             return Some(Duration::ZERO);
         }
-        let shift = (attempt - 1).min(u32::BITS - 1);
-        self.initial_backoff.checked_mul(1_u32 << shift)
+        let mut delay = self.initial_backoff;
+        for _ in 1..attempt {
+            delay = delay.checked_mul(2)?;
+        }
+        Some(delay)
     }
 }
 
@@ -221,20 +224,15 @@ mod tests {
 
     #[tokio::test]
     async fn connect_with_retry_exhausts_attempts_and_returns_error() {
-        // A SQLite path whose parent directory is read-only fails fast, which
-        // mirrors the production failure mode (database unavailable) without
-        // waiting on TCP timeouts. The retry loop must surface the final
-        // error after exhausting attempts instead of hanging or panicking.
-        use std::os::unix::fs::PermissionsExt;
-
+        // A database path under a regular file fails fast on every platform,
+        // mirroring "database unavailable" without TCP timeouts or
+        // platform-specific permission tricks. The retry loop must surface
+        // the final error after exhausting attempts instead of hanging or
+        // panicking.
         let dir = tempfile::tempdir().unwrap();
-        let ro = dir.path().join("ro");
-        std::fs::create_dir(&ro).unwrap();
-        let db_path = ro.join("sub").join("broker.sqlite3");
-
-        let mut perms = std::fs::metadata(&ro).unwrap().permissions();
-        perms.set_mode(0o555);
-        std::fs::set_permissions(&ro, perms).unwrap();
+        let blocker = dir.path().join("blocker");
+        std::fs::write(&blocker, b"regular file, not a directory").unwrap();
+        let db_path = blocker.join("broker.sqlite3");
 
         let target = DatabaseTarget::Sqlite(db_path.to_str().unwrap().to_string());
         let retry = ConnectRetryConfig {
@@ -243,11 +241,6 @@ mod tests {
         };
         let result = DatabaseBackend::connect_with_retry(&target, 2, retry).await;
         assert!(result.is_err());
-
-        // Restore permissions so tempfile can clean up.
-        let mut perms = std::fs::metadata(&ro).unwrap().permissions();
-        perms.set_mode(0o755);
-        std::fs::set_permissions(&ro, perms).unwrap();
     }
 
     #[tokio::test]

--- a/src/db/latest_files.rs
+++ b/src/db/latest_files.rs
@@ -126,13 +126,13 @@ impl LocalBrokerDb {
         }
     }
 
-    pub async fn get_latest_files(&self) -> Vec<BrokerItem> {
+    pub async fn get_latest_files(&self) -> Result<Vec<BrokerItem>, BrokerError> {
         let collector_name_to_info = self
             .collectors
             .iter()
             .map(|c| (c.name.clone(), c.clone()))
             .collect::<HashMap<String, BrokerCollector>>();
-        match sqlx::query(
+        let rows = sqlx::query(
             "select timestamp, collector_name, type, rough_size, exact_size from latest",
         )
         .map(|row: SqliteRow| {
@@ -167,13 +167,7 @@ impl LocalBrokerDb {
             })
         })
         .fetch_all(&self.conn_pool)
-        .await
-        {
-            Ok(items) => items.into_iter().flatten().collect(),
-            Err(e) => {
-                error!("failed to get latest files: {}", e);
-                Vec::new()
-            }
-        }
+        .await?;
+        Ok(rows.into_iter().flatten().collect())
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -7,6 +7,8 @@ mod postgres;
 mod utils;
 
 #[cfg(feature = "cli")]
+pub use backend::ConnectRetryConfig;
+#[cfg(feature = "cli")]
 pub use backend::DatabaseBackend;
 #[cfg(feature = "backend")]
 pub use postgres::PostgresDb;
@@ -112,7 +114,9 @@ impl LocalBrokerDb {
         if !Sqlite::database_exists(path).await? {
             match Sqlite::create_database(path).await {
                 Ok(_) => info!("Created db at {}", path),
-                Err(error) => panic!("error: {}", error),
+                Err(error) => {
+                    return Err(BrokerError::DatabaseError(error));
+                }
             }
         }
 
@@ -1037,7 +1041,7 @@ mod tests {
         let db = LocalBrokerDb::new(db_path_str).await.unwrap();
 
         // Test get_latest_files on empty database
-        let files = db.get_latest_files().await;
+        let files = db.get_latest_files().await.unwrap();
         assert!(files.is_empty());
 
         // Cleanup
@@ -1055,7 +1059,7 @@ mod tests {
         // Test update_latest_files with empty items (should not crash)
         db.update_latest_files(&[], false).await;
 
-        let files = db.get_latest_files().await;
+        let files = db.get_latest_files().await.unwrap();
         assert!(files.is_empty());
 
         // Cleanup

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -10,7 +10,6 @@ use sqlx::postgres::{PgPoolOptions, PgRow};
 use sqlx::{PgPool, Postgres, QueryBuilder, Row};
 use std::collections::HashMap;
 use std::sync::{Arc, RwLock};
-use tracing::error;
 
 /// PostgreSQL adapter for a Broker catalog initialized with
 /// `migration/postgres_bootstrap/bootstrap.py`.
@@ -139,30 +138,19 @@ impl PostgresDb {
         Ok(timestamp.map(|timestamp| timestamp.naive_utc()))
     }
 
-    pub async fn get_latest_files(&self) -> Vec<BrokerItem> {
-        let rows = match sqlx::query(
+    pub async fn get_latest_files(&self) -> Result<Vec<BrokerItem>, BrokerError> {
+        let rows = sqlx::query(
             "SELECT collector_name, timestamp, type, rough_size, exact_size \
              FROM api.mrt_file_latest",
         )
         .fetch_all(&self.conn_pool)
         .await
-        {
-            Ok(rows) => rows,
-            Err(e) => {
-                error!("failed to get latest files: {}", e);
-                return Vec::new();
-            }
-        };
-        let collector_map = match self.collector_map() {
-            Ok(collectors) => collectors,
-            Err(e) => {
-                error!("failed to get collector map for latest files: {}", e);
-                return Vec::new();
-            }
-        };
-        rows.into_iter()
+        .map_err(database_error)?;
+        let collector_map = self.collector_map()?;
+        Ok(rows
+            .into_iter()
             .filter_map(|row| pg_row_to_item(row, &collector_map))
-            .collect()
+            .collect())
     }
 
     pub async fn get_latest_updates_meta(&self) -> Result<Option<UpdatesMeta>, BrokerError> {
@@ -579,7 +567,7 @@ mod tests {
         assert_eq!(inserted.len(), 1);
         assert!(database
             .get_latest_files()
-            .await
+            .await?
             .iter()
             .any(|latest| latest.collector_id == collector.id));
         assert_eq!(database.insert_meta(3, 1).await?.len(), 1);


### PR DESCRIPTION
## Problem

When PostgreSQL is unavailable at broker startup (host reboot, PG maintenance restart, failover), the `serve` command crash-loops: it attempts a single `DatabaseBackend::connect` and `exit(1)`s on failure, relying entirely on Docker's restart backoff to eventually land after the database returns. Observed on the Terrier deployment after a reboot where PG was still binding its address.

A second, quieter bug compounds transient outages: `get_latest_files` swallowed database errors and returned an empty list, which `update_database` interpreted as an empty database. Every update interval during an outage then triggered a full bootstrap re-crawl of all ~86 collectors.

## Changes

- `DatabaseBackend::connect_with_retry`: exponential backoff connect used by both the updater thread and the API on startup; env-tunable via `BGPKIT_BROKER_DB_CONNECT_RETRIES` (default 10) and `BGPKIT_BROKER_DB_CONNECT_BACKOFF_MS` (default 3000)
- `get_latest_files` now returns `Result` across SQLite/Postgres backends; the updater skips the update round on read failure instead of mistaking an outage for an empty database and re-crawling history
- `/latest` and `/missing-collectors` return 503 with the standard error body when the database read fails, instead of an empty 200
- `LocalBrokerDb::new` returns a `BrokerError` instead of panicking when SQLite cannot create the database file (the global panic hook turns panics into exit codes)

## Tests

- retry exhausts attempts and surfaces the final error (read-only parent dir)
- retry succeeds first-try when the database is available
- backoff doubles per attempt and returns `None` on `Duration` overflow instead of panicking
- config defaults cover the new knobs

`cargo fmt --check` clean; `cargo clippy --features cli -- -D warnings` and `--all-features` clean; `cargo test --features cli` green (lib 65+1 ignored, bin 6, doctests 62).