### PR TITLE
feat: consolidate PostgreSQL catalog under broker schema

### DIFF
--- a/migration/postgres_bootstrap/README.md
+++ b/migration/postgres_bootstrap/README.md
@@ -1,23 +1,24 @@
 # Broker SQLite → PostgreSQL bootstrap
 
-This utility imports a Broker SQLite catalog into PostgreSQL and creates a Broker-compatible catalog:
+This utility imports a Broker SQLite catalog into PostgreSQL and creates the `broker` catalog schema for:
 
-- `mrt`: RouteViews/RIPE RIS collectors, archive-file observations, latest-file read model, and crawler update metadata;
-- `api`: Broker-compatible search/latest views.
+- RouteViews/RIPE RIS collectors and archive-file observations;
+- the latest-file read model and crawler update metadata;
+- Broker-compatible search/latest views.
 
-It indexes archive metadata only. Raw MRT payloads stay in archive/object storage. `mrt.file` is an observed catalog entry, not a reachability or routing-forwarding claim.
+It indexes archive metadata only. Raw MRT payloads stay in archive/object storage. `broker.file` is an observed catalog entry, not a reachability or routing-forwarding claim.
 
 ## Data model
 
 The PostgreSQL schema deliberately mirrors Broker’s operational model rather than adding a separate ingestion-provenance layer:
 
-- `mrt.file` holds one catalog entry per `(timestamp, collector, type)`;
-- `mrt.latest_file` is the newest entry per collector/type and is refreshed after a bootstrap or incrementally maintained by the crawler;
-- `mrt.update_meta` mirrors SQLite’s `meta` table: update timestamp, crawler duration, and inserted-row count.
+- `broker.file` holds one catalog entry per `(timestamp, collector, type)`;
+- `broker.latest_file` is the newest entry per collector/type and is refreshed after a bootstrap or incrementally maintained by the crawler;
+- `broker.update_meta` mirrors SQLite’s `meta` table: update timestamp, crawler duration, and inserted-row count.
 
 The importer preserves zero sizes (`0` remains `0`); it does not reinterpret zero as unknown.
 
-The compatibility view is `api.mrt_file_search`:
+The read-only compatibility views are `broker.file_search_view` and `broker.file_latest_view`:
 
 | SQLite `files_view` | PostgreSQL view |
 |---|---|
@@ -35,7 +36,11 @@ python3 migration/postgres_bootstrap/bootstrap.py \
   --batch-size 100000 --reset
 ```
 
-`--reset` drops and recreates only the `api` and `mrt` schemas. Use it for a fresh catalog bootstrap, not an existing database whose catalog contents must be retained.
+`--reset` drops and recreates only the `broker` schema **only when no other schema has a foreign key into it**. The bootstrap aborts instead of cascading through a consumer constraint such as `spectrum.processing → broker.file`. Use it for a fresh disposable catalog database, not an existing shared database whose catalog contents or dependencies must be retained.
+
+### Existing `mrt` + `api` catalog
+
+For the pre-`broker` layout, stop Broker and Spectrum writers, take a verified PostgreSQL backup, then run [`migrate_mrt_api_to_broker.sql`](migrate_mrt_api_to_broker.sql). It renames the catalog schema and moves the two read views without rewriting rows; it preserves the composite foreign key from `spectrum.processing` to the canonical Broker file identity.
 
 The importer exits non-zero if SQLite/PostgreSQL file or collector counts differ. It creates query indexes and runs `ANALYZE` after import.
 

--- a/migration/postgres_bootstrap/bootstrap.py
+++ b/migration/postgres_bootstrap/bootstrap.py
@@ -52,10 +52,44 @@ def schema_sql() -> str:
     return (Path(__file__).parent / "schema.sql").read_text(encoding="utf-8")
 
 
+def reset_dependency_check_sql() -> str:
+    return """
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.table_constraints AS foreign_key
+            JOIN information_schema.constraint_column_usage AS referenced
+              USING (constraint_catalog, constraint_schema, constraint_name)
+            WHERE foreign_key.constraint_type = 'FOREIGN KEY'
+              AND referenced.table_schema = 'broker'
+              AND foreign_key.table_schema <> 'broker'
+        )
+    """
+
+
+def reset_drop_statements() -> tuple[str, ...]:
+    return (
+        "DROP VIEW IF EXISTS broker.file_search_view",
+        "DROP VIEW IF EXISTS broker.file_latest_view",
+        "DROP TABLE IF EXISTS broker.update_meta",
+        "DROP TABLE IF EXISTS broker.latest_file",
+        "DROP TABLE IF EXISTS broker.file",
+        "DROP TABLE IF EXISTS broker.collector",
+        "DROP TABLE IF EXISTS broker.project",
+        "DROP SCHEMA IF EXISTS broker",
+    )
+
+
 def execute_schema(connection, reset: bool) -> None:
     with connection.cursor() as cursor:
         if reset:
-            cursor.execute("DROP SCHEMA IF EXISTS api CASCADE; DROP SCHEMA IF EXISTS mrt CASCADE;")
+            cursor.execute(reset_dependency_check_sql())
+            if cursor.fetchone()[0]:
+                raise RuntimeError(
+                    "refusing --reset: another schema has a foreign key into broker; "
+                    "use a disposable database or remove the dependency deliberately"
+                )
+            for statement in reset_drop_statements():
+                cursor.execute(statement)
         cursor.execute(schema_sql())
     connection.commit()
 
@@ -63,9 +97,9 @@ def execute_schema(connection, reset: bool) -> None:
 def import_collectors(sqlite_db: sqlite3.Connection, pg) -> tuple[dict[int, int], dict[int, str]]:
     with pg.cursor() as cursor:
         for name in ("ripe-ris", "route-views"):
-            cursor.execute("INSERT INTO mrt.project (name) VALUES (%s) ON CONFLICT DO NOTHING", (name,))
+            cursor.execute("INSERT INTO broker.project (name) VALUES (%s) ON CONFLICT DO NOTHING", (name,))
 
-        project_ids = dict(cursor.execute("SELECT name, project_id FROM mrt.project").fetchall())
+        project_ids = dict(cursor.execute("SELECT name, project_id FROM broker.project").fetchall())
         collector_ids: dict[int, int] = {}
         for legacy_id, name, url, project, interval in sqlite_db.execute(
             "SELECT id, name, url, project, updates_interval FROM collectors WHERE name IS NOT NULL ORDER BY id"
@@ -73,7 +107,7 @@ def import_collectors(sqlite_db: sqlite3.Connection, pg) -> tuple[dict[int, int]
             normalized_project = project_name(project)
             cursor.execute(
                 """
-                INSERT INTO mrt.collector (project_id, name, base_uri, updates_interval_seconds)
+                INSERT INTO broker.collector (project_id, name, base_uri, updates_interval_seconds)
                 VALUES (%s, %s, %s, %s)
                 ON CONFLICT (project_id, name) DO UPDATE
                     SET base_uri = EXCLUDED.base_uri,
@@ -106,7 +140,7 @@ def copy_files(sqlite_db: sqlite3.Connection, pg, collector_ids: dict[int, int],
                     copy.write_row(row)
             cursor.execute(
                 """
-                INSERT INTO mrt.file (ts_start, collector_id, data_type, rough_size, exact_size)
+                INSERT INTO broker.file (ts_start, collector_id, data_type, rough_size, exact_size)
                 SELECT to_timestamp(ts_epoch), collector_id, data_type, rough_size, exact_size
                 FROM broker_file_stage
                 ON CONFLICT (ts_start, collector_id, data_type) DO NOTHING
@@ -121,14 +155,14 @@ def copy_files(sqlite_db: sqlite3.Connection, pg, collector_ids: dict[int, int],
 
 def refresh_latest(pg) -> int:
     with pg.cursor() as cursor:
-        cursor.execute("TRUNCATE mrt.latest_file")
+        cursor.execute("TRUNCATE broker.latest_file")
         cursor.execute(
             """
-            INSERT INTO mrt.latest_file
+            INSERT INTO broker.latest_file
                 (collector_id, data_type, ts_start, rough_size, exact_size)
             SELECT DISTINCT ON (collector_id, data_type)
                 collector_id, data_type, ts_start, rough_size, exact_size
-            FROM mrt.file
+            FROM broker.file
             ORDER BY collector_id, data_type, ts_start DESC
             """
         )
@@ -142,9 +176,9 @@ def import_update_meta(sqlite_db: sqlite3.Connection, pg) -> int:
     if not rows:
         return 0
     with pg.cursor() as cursor:
-        cursor.execute("TRUNCATE mrt.update_meta")
+        cursor.execute("TRUNCATE broker.update_meta")
         with cursor.copy(
-            "COPY mrt.update_meta (update_ts, update_duration_seconds, insert_count) FROM STDIN"
+            "COPY broker.update_meta (update_ts, update_duration_seconds, insert_count) FROM STDIN"
         ) as copy:
             for update_ts, duration, inserts in rows:
                 copy.write_row((datetime.fromtimestamp(update_ts, timezone.utc), duration, inserts))
@@ -154,10 +188,10 @@ def import_update_meta(sqlite_db: sqlite3.Connection, pg) -> int:
 
 def create_indexes(pg) -> None:
     with pg.cursor() as cursor:
-        cursor.execute("CREATE INDEX IF NOT EXISTS mrt_file_collector_type_ts_idx ON mrt.file (collector_id, data_type, ts_start)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS mrt_file_type_ts_idx ON mrt.file (data_type, ts_start)")
-        cursor.execute("CREATE INDEX IF NOT EXISTS mrt_update_meta_ts_idx ON mrt.update_meta (update_ts DESC)")
-        cursor.execute("ANALYZE mrt.file; ANALYZE mrt.collector; ANALYZE mrt.latest_file")
+        cursor.execute("CREATE INDEX IF NOT EXISTS broker_file_collector_type_ts_idx ON broker.file (collector_id, data_type, ts_start)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS broker_file_type_ts_idx ON broker.file (data_type, ts_start)")
+        cursor.execute("CREATE INDEX IF NOT EXISTS broker_update_meta_ts_idx ON broker.update_meta (update_ts DESC)")
+        cursor.execute("ANALYZE broker.file; ANALYZE broker.collector; ANALYZE broker.latest_file")
     pg.commit()
 
 
@@ -165,11 +199,11 @@ def verify(sqlite_db: sqlite3.Connection, pg) -> None:
     sqlite_files = sqlite_db.execute("SELECT COUNT(*) FROM files").fetchone()[0]
     sqlite_collectors = sqlite_db.execute("SELECT COUNT(*) FROM collectors WHERE name IS NOT NULL").fetchone()[0]
     with pg.cursor() as cursor:
-        cursor.execute("SELECT COUNT(*), min(ts_start), max(ts_start) FROM mrt.file")
+        cursor.execute("SELECT COUNT(*), min(ts_start), max(ts_start) FROM broker.file")
         pg_files, minimum, maximum = cursor.fetchone()
-        cursor.execute("SELECT COUNT(*) FROM mrt.collector")
+        cursor.execute("SELECT COUNT(*) FROM broker.collector")
         pg_collectors = cursor.fetchone()[0]
-        cursor.execute("SELECT COUNT(*) FROM mrt.latest_file")
+        cursor.execute("SELECT COUNT(*) FROM broker.latest_file")
         latest = cursor.fetchone()[0]
     if sqlite_files != pg_files or sqlite_collectors != pg_collectors:
         raise RuntimeError(f"verification failed: SQLite files/collectors={sqlite_files}/{sqlite_collectors}; PostgreSQL={pg_files}/{pg_collectors}")
@@ -181,7 +215,7 @@ def main() -> int:
     parser.add_argument("sqlite_path", type=Path)
     parser.add_argument("--database-url", required=True, help="libpq URL, normally postgresql:///bgpkit_platform?host=/var/run/postgresql")
     parser.add_argument("--batch-size", type=int, default=BATCH_SIZE)
-    parser.add_argument("--reset", action="store_true", help="drop only api and mrt schemas before import")
+    parser.add_argument("--reset", action="store_true", help="drop only the broker schema before import")
     args = parser.parse_args()
     if args.batch_size < 1:
         parser.error("--batch-size must be positive")

--- a/migration/postgres_bootstrap/migrate_mrt_api_to_broker.sql
+++ b/migration/postgres_bootstrap/migrate_mrt_api_to_broker.sql
@@ -1,0 +1,40 @@
+-- Consolidate the legacy PostgreSQL Broker namespaces into broker.
+--
+-- Preconditions:
+--   * Stop Broker and Spectrum writers.
+--   * Take a verified PostgreSQL backup.
+--   * Run as the owner of mrt and api, or a PostgreSQL superuser.
+--
+-- This is a metadata-only migration. ALTER SCHEMA preserves table rows, indexes,
+-- constraints, sequences, and foreign-key dependencies, including Spectrum's
+-- foreign key to the canonical Broker file identity.
+
+BEGIN;
+
+LOCK TABLE
+    mrt.project,
+    mrt.collector,
+    mrt.file,
+    mrt.latest_file,
+    mrt.update_meta
+IN ACCESS EXCLUSIVE MODE;
+
+ALTER SCHEMA mrt RENAME TO broker;
+
+ALTER INDEX IF EXISTS broker.mrt_file_collector_type_ts_idx
+    RENAME TO broker_file_collector_type_ts_idx;
+ALTER INDEX IF EXISTS broker.mrt_file_type_ts_idx
+    RENAME TO broker_file_type_ts_idx;
+ALTER INDEX IF EXISTS broker.mrt_update_meta_ts_idx
+    RENAME TO broker_update_meta_ts_idx;
+
+ALTER VIEW api.mrt_file_search SET SCHEMA broker;
+ALTER VIEW broker.mrt_file_search RENAME TO file_search_view;
+ALTER VIEW api.mrt_file_latest SET SCHEMA broker;
+ALTER VIEW broker.mrt_file_latest RENAME TO file_latest_view;
+
+-- The two views were the only intended api objects. This fails rather than
+-- cascading if an unexpected object remains, preserving an audit opportunity.
+DROP SCHEMA api;
+
+COMMIT;

--- a/migration/postgres_bootstrap/schema.sql
+++ b/migration/postgres_bootstrap/schema.sql
@@ -1,17 +1,16 @@
 -- PostgreSQL catalog backing the BGPKIT Broker API.
 -- Raw MRT payloads remain in archive/object storage; this database indexes metadata.
 
-CREATE SCHEMA IF NOT EXISTS mrt;
-CREATE SCHEMA IF NOT EXISTS api;
+CREATE SCHEMA IF NOT EXISTS broker;
 
-CREATE TABLE IF NOT EXISTS mrt.project (
+CREATE TABLE IF NOT EXISTS broker.project (
     project_id SMALLINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     name TEXT NOT NULL UNIQUE CHECK (name IN ('ripe-ris', 'route-views'))
 );
 
-CREATE TABLE IF NOT EXISTS mrt.collector (
+CREATE TABLE IF NOT EXISTS broker.collector (
     collector_id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
-    project_id SMALLINT NOT NULL REFERENCES mrt.project(project_id),
+    project_id SMALLINT NOT NULL REFERENCES broker.project(project_id),
     name TEXT NOT NULL,
     base_uri TEXT NOT NULL,
     updates_interval_seconds INTEGER NOT NULL CHECK (updates_interval_seconds > 0),
@@ -19,9 +18,9 @@ CREATE TABLE IF NOT EXISTS mrt.collector (
 );
 
 -- One row is an observed archive object catalog entry, not a guarantee of reachability.
-CREATE TABLE IF NOT EXISTS mrt.file (
+CREATE TABLE IF NOT EXISTS broker.file (
     ts_start TIMESTAMPTZ NOT NULL,
-    collector_id BIGINT NOT NULL REFERENCES mrt.collector(collector_id),
+    collector_id BIGINT NOT NULL REFERENCES broker.collector(collector_id),
     data_type TEXT NOT NULL CHECK (data_type IN ('rib', 'updates')),
     rough_size BIGINT NOT NULL DEFAULT 0 CHECK (rough_size >= 0),
     exact_size BIGINT NOT NULL DEFAULT 0 CHECK (exact_size >= 0),
@@ -29,8 +28,8 @@ CREATE TABLE IF NOT EXISTS mrt.file (
 );
 
 -- Compatibility/read model: refreshed after each complete ingest.
-CREATE TABLE IF NOT EXISTS mrt.latest_file (
-    collector_id BIGINT NOT NULL REFERENCES mrt.collector(collector_id),
+CREATE TABLE IF NOT EXISTS broker.latest_file (
+    collector_id BIGINT NOT NULL REFERENCES broker.collector(collector_id),
     data_type TEXT NOT NULL CHECK (data_type IN ('rib', 'updates')),
     ts_start TIMESTAMPTZ NOT NULL,
     rough_size BIGINT NOT NULL DEFAULT 0,
@@ -39,13 +38,13 @@ CREATE TABLE IF NOT EXISTS mrt.latest_file (
 );
 
 -- Mirrors the SQLite Broker `meta` table for operational update status.
-CREATE TABLE IF NOT EXISTS mrt.update_meta (
+CREATE TABLE IF NOT EXISTS broker.update_meta (
     update_ts TIMESTAMPTZ NOT NULL,
     update_duration_seconds INTEGER NOT NULL,
     insert_count INTEGER NOT NULL
 );
 
-CREATE OR REPLACE VIEW api.mrt_file_search AS
+CREATE OR REPLACE VIEW broker.file_search_view AS
 SELECT
     f.ts_start AS timestamp,
     f.rough_size,
@@ -55,11 +54,11 @@ SELECT
     c.base_uri AS collector_url,
     p.name AS project_name,
     c.updates_interval_seconds AS updates_interval
-FROM mrt.file AS f
-JOIN mrt.collector AS c USING (collector_id)
-JOIN mrt.project AS p USING (project_id);
+FROM broker.file AS f
+JOIN broker.collector AS c USING (collector_id)
+JOIN broker.project AS p USING (project_id);
 
-CREATE OR REPLACE VIEW api.mrt_file_latest AS
+CREATE OR REPLACE VIEW broker.file_latest_view AS
 SELECT
     l.ts_start AS timestamp,
     l.rough_size,
@@ -69,6 +68,6 @@ SELECT
     c.base_uri AS collector_url,
     p.name AS project_name,
     c.updates_interval_seconds AS updates_interval
-FROM mrt.latest_file AS l
-JOIN mrt.collector AS c USING (collector_id)
-JOIN mrt.project AS p USING (project_id);
+FROM broker.latest_file AS l
+JOIN broker.collector AS c USING (collector_id)
+JOIN broker.project AS p USING (project_id);

--- a/migration/postgres_bootstrap/tests/test_bootstrap.py
+++ b/migration/postgres_bootstrap/tests/test_bootstrap.py
@@ -34,9 +34,50 @@ class BootstrapHelpersTests(unittest.TestCase):
 
     def test_schema_uses_operational_update_metadata_without_provenance_tables(self):
         schema = bootstrap.schema_sql()
-        self.assertIn("CREATE TABLE IF NOT EXISTS mrt.update_meta", schema)
+        self.assertIn("CREATE TABLE IF NOT EXISTS broker.update_meta", schema)
         self.assertNotIn("meta.source_revision", schema)
         self.assertNotIn("meta.ingest_run", schema)
+
+    def test_schema_uses_broker_namespace_and_suffixes_read_views(self):
+        schema = bootstrap.schema_sql()
+        self.assertIn("CREATE SCHEMA IF NOT EXISTS broker", schema)
+        self.assertIn("CREATE TABLE IF NOT EXISTS broker.file", schema)
+        self.assertIn("CREATE OR REPLACE VIEW broker.file_search_view", schema)
+        self.assertIn("CREATE OR REPLACE VIEW broker.file_latest_view", schema)
+        self.assertNotIn("mrt.", schema)
+        self.assertNotIn("api.", schema)
+
+    def test_live_migration_renames_broker_schema_and_views_without_dropping_data(self):
+        migration = (Path(__file__).parents[1] / "migrate_mrt_api_to_broker.sql").read_text()
+        self.assertIn("ALTER SCHEMA mrt RENAME TO broker", migration)
+        self.assertIn("ALTER VIEW api.mrt_file_search SET SCHEMA broker", migration)
+        self.assertIn("ALTER VIEW broker.mrt_file_search RENAME TO file_search_view", migration)
+        self.assertIn("ALTER VIEW api.mrt_file_latest SET SCHEMA broker", migration)
+        self.assertIn("ALTER VIEW broker.mrt_file_latest RENAME TO file_latest_view", migration)
+        self.assertNotIn("DROP SCHEMA IF EXISTS mrt CASCADE", migration)
+
+    def test_reset_checks_for_inbound_foreign_keys_before_dropping_broker(self):
+        sql = bootstrap.reset_dependency_check_sql()
+        self.assertIn("constraint_type = 'FOREIGN KEY'", sql)
+        self.assertIn("table_schema = 'broker'", sql)
+        self.assertIn("table_schema <> 'broker'", sql)
+
+    def test_reset_uses_restrictive_schema_drop(self):
+        source = MODULE_PATH.read_text()
+        self.assertNotIn("DROP SCHEMA IF EXISTS broker CASCADE", source)
+        self.assertEqual(
+            bootstrap.reset_drop_statements(),
+            (
+                "DROP VIEW IF EXISTS broker.file_search_view",
+                "DROP VIEW IF EXISTS broker.file_latest_view",
+                "DROP TABLE IF EXISTS broker.update_meta",
+                "DROP TABLE IF EXISTS broker.latest_file",
+                "DROP TABLE IF EXISTS broker.file",
+                "DROP TABLE IF EXISTS broker.collector",
+                "DROP TABLE IF EXISTS broker.project",
+                "DROP SCHEMA IF EXISTS broker",
+            ),
+        )
 
 
 if __name__ == "__main__":

--- a/src/db/postgres.rs
+++ b/src/db/postgres.rs
@@ -41,8 +41,8 @@ impl PostgresDb {
     pub async fn reload_collectors(&self) -> Result<(), BrokerError> {
         let collectors = sqlx::query(
             "SELECT c.collector_id, c.name, c.base_uri, p.name AS project, c.updates_interval_seconds \
-             FROM mrt.collector AS c \
-             JOIN mrt.project AS p USING (project_id) \
+             FROM broker.collector AS c \
+             JOIN broker.project AS p USING (project_id) \
              ORDER BY c.collector_id",
         )
         .map(|row: PgRow| BrokerCollector {
@@ -97,7 +97,7 @@ impl PostgresDb {
 
         let mut query = QueryBuilder::<Postgres>::new(
             "SELECT collector_name, timestamp, type, rough_size, exact_size \
-             FROM api.mrt_file_search",
+             FROM broker.file_search_view",
         );
         apply_search_filters(
             &mut query,
@@ -131,7 +131,7 @@ impl PostgresDb {
 
     pub async fn get_latest_timestamp(&self) -> Result<Option<NaiveDateTime>, BrokerError> {
         let timestamp: Option<DateTime<Utc>> =
-            sqlx::query_scalar("SELECT max(ts_start) FROM mrt.file")
+            sqlx::query_scalar("SELECT max(ts_start) FROM broker.file")
                 .fetch_one(&self.conn_pool)
                 .await
                 .map_err(database_error)?;
@@ -141,7 +141,7 @@ impl PostgresDb {
     pub async fn get_latest_files(&self) -> Result<Vec<BrokerItem>, BrokerError> {
         let rows = sqlx::query(
             "SELECT collector_name, timestamp, type, rough_size, exact_size \
-             FROM api.mrt_file_latest",
+             FROM broker.file_latest_view",
         )
         .fetch_all(&self.conn_pool)
         .await
@@ -157,7 +157,7 @@ impl PostgresDb {
         let row = sqlx::query(
             "SELECT extract(epoch FROM update_ts)::bigint AS update_ts, \
                 update_duration_seconds AS update_duration, insert_count \
-             FROM mrt.update_meta ORDER BY update_ts DESC LIMIT 1",
+             FROM broker.update_meta ORDER BY update_ts DESC LIMIT 1",
         )
         .fetch_optional(&self.conn_pool)
         .await
@@ -171,9 +171,9 @@ impl PostgresDb {
 
     pub async fn analyze(&self) -> Result<(), BrokerError> {
         for statement in [
-            "ANALYZE mrt.file",
-            "ANALYZE mrt.collector",
-            "ANALYZE mrt.latest_file",
+            "ANALYZE broker.file",
+            "ANALYZE broker.collector",
+            "ANALYZE broker.latest_file",
         ] {
             sqlx::query(statement)
                 .execute(&self.conn_pool)
@@ -206,7 +206,7 @@ impl PostgresDb {
                 continue;
             }
             let mut query = QueryBuilder::<Postgres>::new(
-                "INSERT INTO mrt.file (ts_start, collector_id, data_type, rough_size, exact_size) ",
+                "INSERT INTO broker.file (ts_start, collector_id, data_type, rough_size, exact_size) ",
             );
             query.push_values(resolvable.iter(), |mut values, item| {
                 let collector_id = collector_map[item.collector_id.as_str()].id;
@@ -246,8 +246,8 @@ impl PostgresDb {
         let project = normalize_project(&collector.project)?;
         let interval = if project == "ripe-ris" { 300 } else { 900 };
         sqlx::query(
-            "INSERT INTO mrt.collector (project_id, name, base_uri, updates_interval_seconds) \
-             SELECT project_id, $1, $2, $3 FROM mrt.project WHERE name = $4 \
+            "INSERT INTO broker.collector (project_id, name, base_uri, updates_interval_seconds) \
+             SELECT project_id, $1, $2, $3 FROM broker.project WHERE name = $4 \
              ON CONFLICT (project_id, name) DO UPDATE SET \
                  base_uri = EXCLUDED.base_uri, updates_interval_seconds = EXCLUDED.updates_interval_seconds",
         )
@@ -267,15 +267,15 @@ impl PostgresDb {
         bootstrap: bool,
     ) -> Result<(), BrokerError> {
         if bootstrap {
-            sqlx::query("TRUNCATE mrt.latest_file")
+            sqlx::query("TRUNCATE broker.latest_file")
                 .execute(&self.conn_pool)
                 .await
                 .map_err(database_error)?;
             sqlx::query(
-                "INSERT INTO mrt.latest_file (collector_id, data_type, ts_start, rough_size, exact_size) \
+                "INSERT INTO broker.latest_file (collector_id, data_type, ts_start, rough_size, exact_size) \
                  SELECT DISTINCT ON (collector_id, data_type) \
                     collector_id, data_type, ts_start, rough_size, exact_size \
-                 FROM mrt.file ORDER BY collector_id, data_type, ts_start DESC",
+                 FROM broker.file ORDER BY collector_id, data_type, ts_start DESC",
             )
             .execute(&self.conn_pool)
             .await
@@ -303,7 +303,7 @@ impl PostgresDb {
         let latest: Vec<_> = latest_by_key.into_values().collect();
         for batch in latest.chunks(1000) {
             let mut query = QueryBuilder::<Postgres>::new(
-                "INSERT INTO mrt.latest_file (collector_id, data_type, ts_start, rough_size, exact_size) ",
+                "INSERT INTO broker.latest_file (collector_id, data_type, ts_start, rough_size, exact_size) ",
             );
             query.push_values(batch, |mut values, item| {
                 let collector_id = collector_map[item.collector_id.as_str()].id;
@@ -318,7 +318,7 @@ impl PostgresDb {
                 " ON CONFLICT (collector_id, data_type) DO UPDATE SET \
                     ts_start = EXCLUDED.ts_start, rough_size = EXCLUDED.rough_size, \
                     exact_size = EXCLUDED.exact_size \
-                  WHERE EXCLUDED.ts_start > mrt.latest_file.ts_start",
+                  WHERE EXCLUDED.ts_start > broker.latest_file.ts_start",
             );
             query
                 .build()
@@ -335,7 +335,7 @@ impl PostgresDb {
         item_inserted: i32,
     ) -> Result<Vec<UpdatesMeta>, BrokerError> {
         let row = sqlx::query(
-            "INSERT INTO mrt.update_meta (update_ts, update_duration_seconds, insert_count) \
+            "INSERT INTO broker.update_meta (update_ts, update_duration_seconds, insert_count) \
              VALUES (now(), $1, $2) \
              RETURNING extract(epoch FROM update_ts)::bigint AS update_ts, \
                        update_duration_seconds AS update_duration, insert_count",
@@ -354,7 +354,7 @@ impl PostgresDb {
 
     pub async fn cleanup_old_meta_entries(&self, retention_days: i64) -> Result<(), BrokerError> {
         sqlx::query(
-            "DELETE FROM mrt.update_meta WHERE update_ts < now() - ($1::bigint * interval '1 day')",
+            "DELETE FROM broker.update_meta WHERE update_ts < now() - ($1::bigint * interval '1 day')",
         )
         .bind(retention_days)
         .execute(&self.conn_pool)
@@ -385,7 +385,8 @@ impl PostgresDb {
         ts_start: Option<NaiveDateTime>,
         ts_end: Option<NaiveDateTime>,
     ) -> Result<usize, BrokerError> {
-        let mut query = QueryBuilder::<Postgres>::new("SELECT count(*) FROM api.mrt_file_search");
+        let mut query =
+            QueryBuilder::<Postgres>::new("SELECT count(*) FROM broker.file_search_view");
         apply_search_filters(&mut query, collectors, project, data_type, ts_start, ts_end);
         let total: i64 = query
             .build_query_scalar()


### PR DESCRIPTION
## Summary
- consolidate the PostgreSQL Broker catalog from `mrt` and `api` into `broker`
- expose `broker.file_search_view` and `broker.file_latest_view`
- provide a transactional live migration that preserves dependent foreign-key constraints
- reject unsafe bootstrap resets when another schema references `broker`

## Validation
- `cargo fmt --check`
- `python3 -m unittest migration.postgres_bootstrap.tests.test_bootstrap -v`
- `cargo build --features cli --verbose`
- `cargo test --no-default-features --verbose`
- `cargo clippy --all-features -- -D warnings`
- disposable PostgreSQL migration and Postgres adapter integration tests